### PR TITLE
Add trail-of-bits-security-skills to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 🔒 Security & Performance
 
+#### trail-of-bits-security-skills
+**Source:** [trailofbits/skills](https://github.com/trailofbits/skills) | **Verified:** ⏳
+**Description:** Security skills for code auditing and vulnerability detection using static analysis tools.
+**Use Case:** Static analysis with CodeQL/Semgrep, variant analysis across codebases, fix verification, differential code review.
+**Stars:** ⭐⭐⭐⭐⭐
+
 #### security-review
 **Status:** Community-needed
 **Description:** Automated vulnerability scanning and OWASP compliance checks.


### PR DESCRIPTION
Adds Trail of Bits Security Skills to the Security & Performance section.

**Skill:** [trail-of-bits-security-skills](https://github.com/trailofbits/skills)

**Description:** Security skills for code auditing and vulnerability detection using static analysis tools.

**Use Case:** Static analysis with CodeQL/Semgrep, variant analysis across codebases, fix verification, differential code review.

**Features:**
- 17 security-focused skills
- Static analysis toolkit integration
- Variant analysis across codebases
- Fix verification and differential code review

Licensed under CC BY-SA 4.0.