### PR TITLE
Add wondelai/skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [wondelai/skills](https://github.com/wondelai/skills) | 25 | @wondelai | UX design, marketing/CRO, sales, product strategy & growth |
 
 ---
 


### PR DESCRIPTION
Adds [wondelai/skills](https://github.com/wondelai/skills) to the Skill Collections table — 25 agent skills covering UX design, marketing/CRO, sales, product strategy, and business growth. Install: `npx skills add wondelai/skills`. License: MIT.