### PR TITLE
Add chrome-store-publish - Chrome Web Store publishing automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Code smell detection and systematic refactoring techniques.
 **Use Case:** Legacy code modernization, improving code quality
 
+#### chrome-store-publish
+**Source:** [ofelipelourenco/chrome-store-publish](https://github.com/ofelipelourenco/chrome-store-publish) | **Verified:** ⏳
+**Description:** Automates Chrome extension preparation for Chrome Web Store publishing with 7-phase workflow (audit, cleanup, build, legal, listing, assets, validation).
+**Use Case:** Chrome extension publishing, MV3 compliance, store submission prep
+**Stars:** ⭐⭐⭐
+
 ---
 
 ### 🔒 Security & Performance


### PR DESCRIPTION
## chrome-store-publish

**Description:** Claude Code skill that automates Chrome extension preparation for Chrome Web Store publishing. 7-phase workflow from permission audit to submission-ready package.

**Repository:** https://github.com/ofelipelourenco/chrome-store-publish

**Key Features:**
- Automatic permission audit (flags unused APIs)
- MV3 compliance enforcement
- Clean production ZIP builder
- Privacy policy generator (GDPR-aware)
- Store listing copy writer
- Screenshot/asset generator (HTML → PNG via Playwright)
- 17-point pre-submission validation

**Use Case:** Chrome extension developers preparing for Chrome Web Store submission.

**Status:** Stable, fully documented, Apache 2.0 licensed.