### PR TITLE
Add OpenPaw to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [OpenPaw](https://github.com/daxaur/openpaw) | 38 | @daxaur | Personal assistant — email, calendar, Spotify, smart home, Slack, GitHub, and more (`npx pawmode`) |
 
 ---
 


### PR DESCRIPTION
Adds [OpenPaw](https://github.com/daxaur/openpaw) to the Skill Collections table.

OpenPaw is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. No daemon, no cloud, MIT licensed.

- Repo: https://github.com/daxaur/openpaw
- npm: https://www.npmjs.com/package/pawmode