### PR TITLE
Add noizai-skills entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** GitHub Actions workflow creation and automated deployment pipelines.
 **Use Case:** DevOps automation, continuous delivery
 
+#### noizai-skills
+**Source:** [NoizAI/skills](https://github.com/NoizAI/skills) | **Verified:** ⏳
+**Description:** Human-like TTS workflow skills with style control and app delivery.
+**Use Case:** Natural voice generation, audio broadcasting, cross-app voice messaging
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### 🎬 Media & Content Creation


### PR DESCRIPTION
## Summary
- add `noizai-skills` in the Documentation & Automation section
- follow the repository entry format (`Source`, `Description`, `Use Case`, `Stars`)

## Why
- addresses the listing request for NoizAI/skills in this awesome list

Closes #24

Made with [Cursor](https://cursor.com)