### PR TITLE
Add affiliate-skills — 45 AI agent skills for affiliate marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [Affitor/affiliate-skills](https://github.com/Affitor/affiliate-skills) | 45 | @Affitor | Affiliate marketing full funnel: research, content, SEO, landing pages, distribution, analytics, automation |
 
 ---
 


### PR DESCRIPTION
## Add affiliate-skills

**Repository:** https://github.com/Affitor/affiliate-skills
**License:** MIT
**Skills:** 45
**Standard:** [agentskills.io](https://agentskills.io)

### What it is

45 open-source AI agent skills for affiliate marketing. Full funnel: research, content, SEO, landing pages, distribution, analytics, automation. Works with Claude Code, ChatGPT, Gemini, Cursor, Windsurf.

### Compatibility

Claude Code, ChatGPT, Gemini CLI, Cursor, Windsurf, OpenClaw, any AI agent.

### Install

```bash
npx skills add Affitor/affiliate-skills
```

### Why include it

- Largest open-source affiliate marketing skill collection (45 skills)
- Follows agentskills.io standard
- Full funnel coverage (8 stages with closed-loop flywheel)
- Works across all major AI coding agents
- Active development, MIT licensed