### PR TITLE
feat: add itsmemeworks/adhx to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [itsmemeworks/adhx](https://github.com/itsmemeworks/adhx) | 1 | @itsmemeworks | X/Twitter post reader — fetches posts as clean LLM-friendly JSON |
 
 ---
 


### PR DESCRIPTION
# Pull Request: Add ADHX Skill

## Skill Information

- **Skill Name:** ADHX - X/Twitter Post Reader
- - **Category:** 📊 Data & Analysis / Skill Collections
- - **Repository URL:** https://github.com/itsmemeworks/adhx
- - **I am the author of this skill:** [x] Yes
## What this adds

Adds ADHX (https://adhx.com) to the Skill Collections table. ADHX is an open-source Claude Code skill that fetches any X/Twitter post as clean LLM-friendly JSON. No scraping or browser required. Works with both regular tweets and full X Articles.

**Install:**
```
/plugin marketplace add itsmemeworks/adhx
```
```bash
curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md
```

## Quality Checklist

- [x] Has working `SKILL.md` file with YAML frontmatter
- [ ] - [x] Clear, concise documentation
- [ ] - [x] Actively maintained repository
- [ ] - [x] No security vulnerabilities
- [ ] - [x] Relevant to Claude workflows