### PR TITLE
Add shipwise — webapp launch lifecycle plugin (15 skills, 45+ reference docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Code smell detection and systematic refactoring techniques.
 **Use Case:** Legacy code modernization, improving code quality
 
+#### shipwise
+**Source:** [harmansidhudev/shipwise](https://github.com/harmansidhudev/shipwise) | **Verified:** ✅
+**Description:** 15-skill webapp launch lifecycle plugin covering idea validation, architecture, fullstack development, OWASP security, billing, legal compliance, and growth ops. Includes codebase auditor, deploy gate hooks, and experience-level calibration. 12/12 test scenarios passed.
+**Use Case:** Full launch lifecycle guidance, pre-deploy security audits, production readiness tracking
+**Stars:** ⭐⭐⭐⭐⭐
+
 ---
 
 ### 🔒 Security & Performance

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 #### shipwise
 **Source:** [harmansidhudev/shipwise](https://github.com/harmansidhudev/shipwise) | **Verified:** ✅
-**Description:** 15-skill webapp launch lifecycle plugin covering idea validation, architecture, fullstack development, OWASP security, billing, legal compliance, and growth ops. Includes codebase auditor, deploy gate hooks, and experience-level calibration. 12/12 test scenarios passed.
+**Description:** 15-skill webapp launch lifecycle plugin covering idea validation, architecture, fullstack development, OWASP security, billing, legal compliance, and growth ops. Includes 60+ reference docs, codebase auditor, deploy gate hooks, and experience-level calibration. 25/25 test scenarios passed.
 **Use Case:** Full launch lifecycle guidance, pre-deploy security audits, production readiness tracking
 **Stars:** ⭐⭐⭐⭐⭐
 


### PR DESCRIPTION
Adding Shipwise, a Claude Code plugin for the full webapp launch lifecycle.

**Overview:**
- 15 domain skills: idea validation, product design, business/legal,
  architecture, fullstack dev, infrastructure, testing, security,
  observability, SEO, billing, legal compliance, launch execution, growth
- 4 lifecycle hooks (session context, edit whispers, deploy gate, progress tracking)
- 45+ reference documents with copy-paste templates
- Codebase auditor that detects your real stack (Prisma, Clerk, Stripe, etc.)
- Experience-level calibration (beginner/intermediate/senior)

**Testing:**
- 12/12 QA scenarios passed
- Before/After auth test: 18/40 → 36/40 (24 specific security improvements)
- Full test results published in repo

**Compatibility:** Claude Code, Codex, Cursor, Gemini CLI, Windsurf, Aider,
OpenCode, Augment, Antigravity

MIT licensed | https://harmansidhudev.github.io/shipwise/