### PR TITLE
Add no-slop prose linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Gather, synthesize, and cite sources for research projects.
 **Use Case:** Academic research, market analysis, competitive intelligence
 
+#### no-slop
+**Source:** [Byk3y/no-slop](https://github.com/Byk3y/no-slop) | **Verified:** ⏳
+**Description:** A prose linter that catches AI writing patterns. 13 rules with 40+ banned words and annotated before/after examples, sourced from Wikipedia's Signs of AI Writing.
+**Use Case:** Blog posts, documentation, emails, PR descriptions, any long-form prose
+**Stars:** ⭐⭐⭐
+
 #### technical-writing
 **Status:** Community-needed
 **Description:** Create clear technical documentation following industry best practices.


### PR DESCRIPTION
## Summary

- Adds [no-slop](https://github.com/Byk3y/no-slop) to the **Writing & Research** section
- A prose linter that catches AI writing patterns before they happen
- 13 rules with 40+ banned words, sourced from [Wikipedia's Signs of AI Writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)
- Includes annotated before/after examples for every rule
- Works with Claude Code, Cursor, and Codex CLI

## Why this belongs here

no-slop is a constraint skill that prevents AI writing patterns during generation rather than fixing them after. It teaches AI agents what to avoid based on Wikipedia's collaboratively maintained, evidence-based list of AI writing tells.