### PR TITLE
Add cera-reasoning-harness to Meta Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Skills are available on Claude Pro, Max, Team, and Enterprise plans with code ex
 | [skill-creator](https://github.com/anthropics/skills) | Create your own skills and contribute to the ecosystem | 🎯 Meta | ✅ |
 | [requesting-code-review](https://github.com/obra/superpowers) | Pre-review preparation with formatted diffs and clear PR descriptions | 🤝 Workflow | ✅ |
 | [subagent-driven-development](https://github.com/obra/superpowers) | Quality-gated iteration with multi-agent workflows for complex tasks | 🎯 Meta | ✅ |
+| [cera-reasoning-harness](https://github.com/miketepUR/cera-reasoning-harness) | Preserves reasoning, logical provenance, and collaborative state across Claude Project sessions — not just facts | 🎯 Meta | ✅ |
 
 ## How to Install Skills
 
@@ -463,6 +464,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Source:** [obra/superpowers](https://github.com/obra/superpowers) | **Verified:** ✅
 **Description:** Quality-gated iteration with multi-agent workflows for complex tasks.
 **Use Case:** Large-scale refactoring, parallel development streams
+**Stars:** ⭐⭐⭐⭐⭐
+
+#### cera-reasoning-harness
+**Source:** [miketepUR/cera-reasoning-harness](https://github.com/miketepUR/cera-reasoning-harness) | **Verified:** ✅
+**Description:** A reasoning harness for Claude Projects. Preserves logical provenance, strategic posture, and collaborative state across sessions — not just facts. Two-tier architecture: per-session reasoning maps + cross-session CERA Index managed by a dedicated integrator. Apache 2.0, patent pending.
+**Use Case:** Long-running projects where reasoning continuity matters more than fact recall (legal strategy, research, systems design, policy analysis)
 **Stars:** ⭐⭐⭐⭐⭐
 
 ---


### PR DESCRIPTION
Adds [cera-reasoning-harness](https://github.com/miketepUR/cera-reasoning-harness) to the Meta Skills section.

## About the skill

CERA (Co-Emergent Reasoning Architecture) is a reasoning harness for Claude Projects that preserves logical provenance, strategic posture, and collaborative state across sessions — not just facts. It uses a two-tier architecture: per-session reasoning maps plus a cross-session CERA Index managed by a dedicated integrator.

- **License:** Apache 2.0
- **Repo:** https://github.com/miketepUR/cera-reasoning-harness
- **Paradigm essay:** https://michael124.substack.com/p/the-reasoning-harness-preserving
- **Patent:** provisional filed February 2026

## Why Meta Skills

CERA is infrastructure-level — it's not a task-specific skill like PDF handling or code review. It changes how Claude Projects accumulate understanding across sessions, which fits the "Meta Skills" category alongside skill-creator and subagent-driven-development.

## Entries added

1. Featured Skills table (line ~87)
2. Meta Skills detailed section (after `subagent-driven-development`)

Happy to adjust formatting, category placement, or descriptions per reviewer feedback.