### PR TITLE
Add inhouseseo/superseo-skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,8 +473,9 @@ Looking for curated skill bundles? Start with these collections:
 
 | Collection | Skills | Maintainer | Focus Area |
 |------------|--------|------------|------------|
-| [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [inhouseseo/superseo-skills](https://github.com/inhouseseo/superseo-skills) | 11 | @inhouseseo | SEO audits, content writing, link building, E-E-A-T |
+| [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 
 ---
 


### PR DESCRIPTION
## Skill Information
- **Skill Name:** inhouseseo/superseo-skills (collection of 11 skills)
- **Category:** Skill Collections
- **Repository:** https://github.com/inhouseseo/superseo-skills
- **I am the author:** [x] Yes [ ] No

## Quality Checklist
- [x] Has working SKILL.md file (one per skill, all 11 with valid YAML frontmatter)
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues (Markdown-only, no executable code)
- [x] Follows format requirements
- [x] Alphabetically sorted within category

## Additional Context

This is a 11-skill bundle for SEO workflows — page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, featured snippets, topic clusters, and link building. Apache 2.0, plugin marketplace install (`/plugin marketplace add inhouseseo/superseo-skills`), works in Claude Code, Claude Desktop, Claude.ai web Skills tab, and Cursor.

I added it to the **Skill Collections** table rather than splitting it across the 11 individual skill categories, since the value is in the bundle (shared methodology, shared anti-AI-slop ruleset, shared content-type templates, etc.) and the contributing guide is explicit about one skill per PR.

The angle that makes it different from the SEO/marketing skills already on Claude: each skill fetches the page and reads top-ranking competitors itself. Users don't paste in keyword data exports or crawl reports — just give it a URL or a keyword.

Sorted the table alphabetically while I was there (anthropics, inhouseseo, obra) so the existing two rows are now in the correct order.