### PR TITLE
Add llm-wiki to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Create clear technical documentation following industry best practices.
 **Use Case:** API docs, user manuals, technical specifications
 
+#### llm-wiki
+**Source:** [praneybehl/llm-wiki-plugin](https://github.com/praneybehl/llm-wiki-plugin) | **Verified:** ⏳
+**Description:** Build a compounding, LLM-curated personal knowledge base in any project — Karpathy's LLM Wiki pattern with sharded indexes, BM25 search, and a structural lint script.
+**Use Case:** Accumulating research notes, literature reviews, second-brain knowledge bases that scale to thousands of pages without becoming a context bottleneck.
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### 🎯 Meta Skills


### PR DESCRIPTION
Adds [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) to **✍️ Writing & Research** using the required format (Source / Description / Use Case / Stars).

## Why this category

Fits alongside `research-assistant` (Community-needed) and `technical-writing` — llm-wiki is specifically about accumulating, cross-referencing, and synthesizing research sources over time. It is an implementation of [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).

## Quality criteria

- ✅ **Working SKILL.md** with valid YAML frontmatter and comprehensive progressive-disclosure references
- ✅ **Clear documentation** — README, CHANGELOG, CONTRIBUTING, plus 6 reference docs (architecture, ingest, query, lint, page-conventions, scaling)
- ✅ **Claude relevance** — Claude Code plugin with marketplace manifest validated via `claude plugin validate .`; also installable via `npx skills add`
- ✅ **Active maintenance** — initial release April 2026
- ✅ **Open source** — MIT, public on GitHub
- ✅ **No malicious code** — 4 stdlib-only Python scripts (no network calls, no shell exec on user-supplied data)
- ⭐ **More than just SKILL.md** — skill + 5 slash commands + 4 scripts + templates + references

I used a self-rated 4⭐ as a first pass (happy to adjust to whatever you think fits). Let me know if you'd prefer a different category — Meta Skills or Documentation & Automation would also be reasonable.