### PR TITLE
Add changelog-automation to Documentation & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,10 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Maintaining up-to-date documentation, API references
 
 #### changelog-automation
-**Status:** Community-needed
-**Description:** Conventional commits integration with automated release note generation.
-**Use Case:** Release management, version tracking
+**Source:** [wyktor33/changelog-automation](https://github.com/wyktor33/changelog-automation) | **Verified:** ⏳
+**Description:** Generate changelogs from conventional commits with type grouping, scope support, and Keep a Changelog output.
+**Use Case:** Release management, version tracking, automated release notes
+**Stars:** ⭐⭐⭐
 
 #### ci-cd-integration
 **Status:** Community-needed

--- a/skills/changelog-automation/README.md
+++ b/skills/changelog-automation/README.md
@@ -1,0 +1,241 @@
+# changelog-automation
+
+A Claude Code skill that generates structured changelogs from git history. Works with conventional commits, freeform messages, tagged releases, or any combination — adapts to what your repo actually has.
+
+## Installation
+
+```bash
+# Clone into your skills directory
+git clone https://github.com/wyktor33/changelog-automation ~/.claude/skills/changelog-automation
+
+# That's it — the skill is available immediately in Claude Code
+```
+
+## Usage
+
+The skill is invoked manually (it writes files, so Claude won't auto-trigger it):
+
+```
+/changelog-automation 2.1.0                     # From last tag to HEAD
+/changelog-automation 2.1.0 --from v2.0.0       # Between two tags
+/changelog-automation --unreleased               # Changes since last tag, no version assigned
+/changelog-automation 1.0.0 --from main --to release/1.0   # Compare branches
+```
+
+If you run it without arguments, the skill will detect your latest tag and ask you for the version number.
+
+### What happens when you invoke it
+
+1. **Assesses your repo** — checks for tags, conventional commits, existing CHANGELOG.md
+2. **Detects the commit range** — uses tags if available, asks you to confirm if not
+3. **Classifies every commit** — parses conventional commits structurally, reads and classifies freeform commits by intent
+4. **Generates a changelog** — Keep a Changelog format with grouped categories
+5. **Asks before writing** — shows you the output first, flags uncertain classifications, lets you correct before saving
+
+### Output format
+
+The skill generates [Keep a Changelog](https://keepachangelog.com/) format:
+
+```markdown
+## [2.1.0] - 2026-04-16
+
+### Breaking Changes
+
+- Change default response format to JSON:API (h8i9j0k)
+
+### Added
+
+- **auth:** Add OAuth2 provider support (a1b2c3d)
+
+### Fixed
+
+- Resolve memory leak in connection pool (c3d4e5f)
+```
+
+See [examples/sample-output.md](examples/sample-output.md) for a full example.
+
+## How Your Repo Affects Output Quality
+
+The skill adapts to any repo, but the quality of its output directly depends on how your team writes commits. Here's what to expect:
+
+| Your repo has... | Skill output quality | What happens |
+|-----------------|---------------------|-------------|
+| Conventional commits + tags | Excellent | Fully structured, no guesswork |
+| Tags but freeform commits | Good | Claude reads and classifies by intent, flags uncertain ones |
+| Conventional commits but no tags | Good | Clean parsing, but you must specify the range manually |
+| Freeform commits, no tags | Usable | Intelligent classification with manual range, expect some flagged items |
+| Squash-merged everything | Limited | Single large commits lose granularity — Claude reads diffs to compensate |
+| WIP/temp/garbage messages | Poor | Most commits skipped — very little to work with |
+
+## Guide: Maintaining a Dev Cycle That Produces Good Changelogs
+
+You don't need to adopt every practice below. Each one independently improves changelog quality. Pick what fits your team.
+
+### Level 1: The Minimum — Write Descriptive Commits
+
+The single highest-impact change. Even without conventions, a descriptive commit message gives the skill enough to classify correctly.
+
+**Bad — the skill can't help you:**
+```
+fix stuff
+update
+WIP
+.
+```
+
+**Good — the skill classifies these accurately:**
+```
+fix race condition in token refresh when multiple tabs are open
+add CSV export to the reports page
+remove deprecated v1 authentication endpoints
+```
+
+**Rules of thumb:**
+- Start with a verb: add, fix, remove, update, refactor, optimize
+- Say what changed AND what it affects
+- If you squash-merge, edit the squash message to be meaningful
+
+### Level 2: Adopt Conventional Commits
+
+[Conventional Commits](https://www.conventionalcommits.org/) give the skill structured data to work with — no guesswork, no flags, exact categorization.
+
+```
+feat(auth): add OAuth2 provider support
+fix: resolve memory leak in connection pool
+feat!: change default response format to JSON:API
+docs: update API reference for v2 endpoints
+```
+
+**Format:** `type(scope): description`
+
+| Type | When to use |
+|------|------------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, no logic change |
+| `refactor` | Code restructuring, no behavior change |
+| `perf` | Performance improvement |
+| `test` | Adding or fixing tests |
+| `build` | Build system or dependencies |
+| `ci` | CI/CD configuration |
+| `chore` | Maintenance, tooling, config |
+| `revert` | Reverting a previous commit |
+
+**Breaking changes:** Add `!` before the colon (`feat!:`) or include a `BREAKING CHANGE:` footer in the commit body.
+
+**Scopes** are optional but useful for larger projects — they let the skill group related changes together (e.g., all `auth` changes, all `api` changes).
+
+### Level 3: Tag Your Releases
+
+Tags give the skill automatic range detection. Without them, you have to specify ranges manually every time.
+
+```bash
+# After merging to main for a release
+git tag -a v2.1.0 -m "Release 2.1.0"
+git push origin v2.1.0
+```
+
+**Conventions that work:**
+- `v1.2.3` (most common)
+- `1.2.3` (also works)
+- Follow [Semantic Versioning](https://semver.org/): MAJOR.MINOR.PATCH
+
+### Level 4: Atomic Commits
+
+One logical change per commit. This gives the skill the best possible input.
+
+**Instead of:**
+```
+implement user dashboard with charts, fix auth bug, update deps
+```
+
+**Do:**
+```
+feat(dashboard): add user activity chart
+feat(dashboard): add revenue summary widget
+fix(auth): prevent session expiry during active use
+chore: update chart.js to v4.2
+```
+
+Each commit maps to exactly one changelog entry. No ambiguity, no lost information.
+
+### Level 5: Clean Branch History Before Merge
+
+If your branch has messy WIP commits, clean them up before merging:
+
+```bash
+# Interactive rebase to squash/reword before merge
+git rebase -i main
+```
+
+Or use squash-merge with a well-written merge commit:
+
+```bash
+# GitHub squash-merge with a proper message
+feat(dashboard): add user activity tracking
+
+- Activity chart with daily/weekly/monthly views
+- Revenue summary widget
+- Export to CSV
+```
+
+The `finishing-a-development-branch` skill from obra/superpowers can guide this process.
+
+## Complementary Skills
+
+This skill produces the best results when your workflow includes these other skills. None are required — each one independently improves output quality.
+
+### Commit Quality (direct impact on changelog)
+
+| Skill | Source | How it helps |
+|-------|--------|-------------|
+| **finishing-a-development-branch** | [obra/superpowers](https://github.com/obra/superpowers) | Guides clean branch history and merge preparation — reduces noise commits |
+| **requesting-code-review** | [obra/superpowers](https://github.com/obra/superpowers) | Encourages well-described, atomic commits during PR preparation |
+
+### Workflow Quality (indirect impact — better process = better commits)
+
+| Skill | Source | How it helps |
+|-------|--------|-------------|
+| **test-driven-development** | [obra/superpowers](https://github.com/obra/superpowers) | TDD produces commits scoped to specific behaviors — maps cleanly to "Added" and "Fixed" entries |
+| **writing-plans** | [obra/superpowers](https://github.com/obra/superpowers) | Planned implementations produce structured commit sequences |
+| **executing-plans** | [obra/superpowers](https://github.com/obra/superpowers) | Checkpoint-based execution produces commits that map to plan steps |
+| **using-git-worktrees** | [obra/superpowers](https://github.com/obra/superpowers) | Isolated workstreams keep feature commits separate from unrelated changes |
+
+### Build & Release (adjacent workflow)
+
+| Skill | Source | How it helps |
+|-------|--------|-------------|
+| **verification-before-completion** | [obra/superpowers](https://github.com/obra/superpowers) | Ensures changes are validated before release — pairs with changelog as a release checklist |
+
+## FAQ
+
+### Does my project need conventional commits for this to work?
+
+No. The skill works with any commit messages. Conventional commits give the best results (exact classification, no guesswork), but Claude can intelligently classify freeform commits by reading them and their diffs.
+
+### Does my project need tags?
+
+No. Tags let the skill automatically detect version ranges. Without tags, you specify the range manually (by date, commit count, or branch comparison).
+
+### What about monorepos?
+
+You can scope the changelog to a subdirectory:
+
+```
+/changelog-automation 2.1.0 --from v2.0.0
+```
+
+Then tell Claude to filter by path: "Only include changes in `packages/api/`". The skill uses `git log -- path/` to scope commits.
+
+### What if most of my commits are WIP or meaningless?
+
+The skill skips noise commits (WIP, temp, fixup, single-character messages) and tells you how many were skipped. If the majority are noise, consider adopting Level 1 practices from the dev cycle guide above.
+
+### Can I edit the output before it's written?
+
+Yes. The skill always shows you the generated changelog first and asks before writing. It also flags uncertain classifications so you can correct them.
+
+## License
+
+MIT

--- a/skills/changelog-automation/SKILL.md
+++ b/skills/changelog-automation/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: changelog-automation
+description: Generate changelogs and release notes from git history. Parses conventional commits when available, intelligently classifies freeform commits when not. Adapts to any repo — tags or no tags.
+when_to_use: When the user asks to generate a changelog, prepare release notes, summarize changes between versions or tags, or update CHANGELOG.md
+disable-model-invocation: true
+argument-hint: "[version] [--from ref] [--to ref] [--unreleased]"
+allowed-tools: Bash(git log *) Bash(git tag *) Bash(git describe *) Bash(git diff *) Bash(git rev-list *) Bash(git rev-parse *)
+---
+
+# Changelog Automation
+
+Generate structured changelogs from git history. Adapts to the repo's actual state — works with conventional commits, freeform messages, tagged releases, or none of the above. Output follows [Keep a Changelog](https://keepachangelog.com/) format.
+
+## When to Use
+
+- User says "generate changelog", "release notes", or "what changed since [version]"
+- Preparing a release and need a summary of all changes
+- Updating an existing CHANGELOG.md with new entries
+
+## Complementary Skills
+
+This skill produces better output when the project also uses:
+
+- **test-driven-development** (obra/superpowers) — TDD commits naturally produce well-scoped, descriptive messages tied to specific behaviors
+- **writing-plans** (obra/superpowers) — planned implementations lead to structured commit sequences rather than ad-hoc fixes
+- **executing-plans** (obra/superpowers) — checkpoint-based execution produces commits that map cleanly to plan steps
+- **requesting-code-review** (obra/superpowers) — PR preparation encourages well-described, atomic commits
+- **finishing-a-development-branch** (obra/superpowers) — clean branch history with squashed or rebased commits reduces noise
+
+Without these, the skill still works — it just has to work harder to classify freeform commits.
+
+## Inputs
+
+- `$ARGUMENTS` — version string and/or flags
+  - `/changelog-automation 2.1.0` — generate changelog for version 2.1.0 (from last tag to HEAD)
+  - `/changelog-automation 2.1.0 --from v2.0.0` — changelog between two specific points
+  - `/changelog-automation --unreleased` — list changes since the last tag without assigning a version
+  - `/changelog-automation 1.0.0 --from main --to release/1.0` — compare branches
+
+If no arguments are provided, prompt the user for the version number. Detect the last tag automatically.
+
+## Core Process
+
+1. **Assess repo** — detect what the repo actually has to work with
+2. **Discover range** — determine the commit range
+3. **Parse and classify commits** — structured or intelligent classification
+4. **Generate output** — format as Keep a Changelog markdown
+5. **Present to user** — show the changelog and ask whether to write/update CHANGELOG.md
+
+---
+
+## Step 1: Assess Repo
+
+Before doing anything, understand what you have to work with. Run these checks:
+
+```bash
+# Check for tags
+TAG_COUNT=$(git tag | wc -l | tr -d ' ')
+
+# Check for conventional commits (sample last 30)
+CONVENTIONAL_COUNT=$(git log -30 --pretty=format:"%s" | grep -cE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?(!)?: ' || true)
+TOTAL_SAMPLE=$(git log -30 --oneline | wc -l | tr -d ' ')
+
+# Check for existing CHANGELOG.md
+CHANGELOG_EXISTS=$(test -f CHANGELOG.md && echo "yes" || echo "no")
+```
+
+Classify the repo into one of four modes:
+
+| Mode | Tags? | Conventional Commits? | Strategy |
+|------|-------|-----------------------|----------|
+| **Structured** | Yes | >70% of sample | Parse conventionally, use tags for ranges |
+| **Tagged-freeform** | Yes | <70% of sample | Intelligent classification, use tags for ranges |
+| **Untagged-conventional** | No | >70% of sample | Parse conventionally, require user-specified range |
+| **Freeform** | No | <70% of sample | Intelligent classification, require user-specified range |
+
+Report the detected mode to the user:
+
+> **Repo assessment:** Found {N} tags, {X}/{Y} recent commits follow conventional format.
+> Using **{mode}** mode.
+
+If mode is **Freeform** or **Tagged-freeform**, add:
+
+> Freeform commits detected. I will read each commit and classify it by intent (feature, fix, refactor, etc.). Results may need light editing.
+
+---
+
+## Step 2: Discover Range
+
+### When tags exist
+
+```bash
+# Get the latest tag
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+
+# If --from flag provided, use that instead
+# Verify the reference exists before using it
+git rev-parse --verify "$FROM_REF" >/dev/null 2>&1
+```
+
+Use the range `$LATEST_TAG..HEAD` unless the user specifies otherwise.
+
+### When no tags exist
+
+Offer these options to the user:
+
+1. **All history** — from initial commit to HEAD (good for first-ever changelog)
+   ```bash
+   INITIAL_COMMIT=$(git rev-list --max-parents=0 HEAD)
+   ```
+2. **Date-based** — "changes since 2026-01-01"
+   ```bash
+   git log --after="2026-01-01" --pretty=format:"%H|%s|%an|%ad" --date=short
+   ```
+3. **Commit-count** — "last 50 commits"
+   ```bash
+   git log -50 --pretty=format:"%H|%s|%an|%ad" --date=short
+   ```
+4. **Branch comparison** — "changes on this branch vs main"
+   ```bash
+   git log main..HEAD --pretty=format:"%H|%s|%an|%ad" --date=short
+   ```
+
+Do not silently default to "all history" — that can be thousands of commits. Always confirm with the user.
+
+---
+
+## Step 3: Parse and Classify Commits
+
+Fetch commits in the range:
+
+```bash
+git log $FROM..$TO --pretty=format:"%H|%s|%an|%ad" --date=short --no-merges
+```
+
+Always exclude merge commits (`--no-merges`).
+
+### For conventional commits
+
+Parse each subject line against this pattern:
+
+```
+^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?(!)?:\s*(.+)$
+```
+
+Components:
+- **type** — the commit type (feat, fix, etc.)
+- **scope** — optional, in parentheses (e.g., `auth`, `api`)
+- **breaking indicator** — `!` before the colon
+- **description** — the rest of the subject line
+
+Also check commit bodies for `BREAKING CHANGE:` or `BREAKING-CHANGE:` footers:
+
+```bash
+git log $FROM..$TO --pretty=format:"%H%n%B%n---END---" --no-merges
+```
+
+### For freeform commits — intelligent classification
+
+This is where Claude adds value no CLI tool can. For each freeform commit:
+
+1. Read the subject line and body
+2. If the diff is small (<50 lines), read it: `git diff $HASH~1..$HASH --stat`
+3. Classify by **intent**, not keywords:
+
+| Intent | Signals | Maps to |
+|--------|---------|---------|
+| New capability | "add", "introduce", "implement", "support", new files created | `### Added` |
+| Bug fix | "fix", "resolve", "correct", "patch", "handle", "prevent", changes in error paths | `### Fixed` |
+| Breaking change | "remove", "drop", "rename public API", "change default", deleted public interfaces | `### Breaking Changes` |
+| Performance | "optimize", "speed", "cache", "reduce memory", "batch" | `### Performance` |
+| Documentation | "readme", "docs", "comment", "jsdoc", changes only in .md or doc files | `### Documentation` |
+| Refactor | "refactor", "extract", "reorganize", "clean up", "rename" (internal), structural changes with no behavior change | `### Changed` |
+| Build/CI | "ci", "pipeline", "docker", "workflow", "deploy", changes in CI config files | `### Build` |
+| Chore | "bump", "update deps", "lint", "format", lock file changes | `### Other` |
+
+**When uncertain**, classify as `### Other` rather than guessing wrong. Flag uncertain classifications to the user:
+
+> Note: I classified "{commit message}" as a fix based on the diff, but the message is ambiguous. Please verify.
+
+### Squashed / vague commits
+
+Some commits are useless for changelogs:
+- `"WIP"`, `"temp"`, `"asdf"`, `"."` — skip these, note them as skipped
+- `"update"`, `"changes"`, `"stuff"` — read the diff to classify, or skip and flag
+- Single mega-commits (500+ lines changed) — warn the user that granularity is lost
+
+---
+
+## Step 4: Generate Output
+
+Group commits into these categories, in this order:
+
+| Category | Heading | Conventional Types |
+|----------|---------|-------------------|
+| Breaking Changes | `### Breaking Changes` | Any type with `!` or `BREAKING CHANGE` footer |
+| Features | `### Added` | `feat` |
+| Bug Fixes | `### Fixed` | `fix` |
+| Performance | `### Performance` | `perf` |
+| Documentation | `### Documentation` | `docs` |
+| Refactoring | `### Changed` | `refactor`, `style` |
+| Build & CI | `### Build` | `build`, `ci` |
+| Other | `### Other` | `chore`, `test`, `revert`, unclassified |
+
+Only include categories that have commits. Skip empty sections.
+
+If a commit appears in Breaking Changes, do NOT also list it under its type category.
+
+### Scope grouping
+
+If scopes are present, group entries by scope within each category:
+
+```markdown
+### Added
+
+- **auth:** Add OAuth2 provider support (a1b2c3d)
+- **auth:** Add session refresh endpoint (b2c3d4e)
+- **api:** Add pagination to list endpoints (c3d4e5f)
+```
+
+If no scopes are present, list entries flat.
+
+### Output template
+
+```markdown
+## [VERSION] - YYYY-MM-DD
+
+### Breaking Changes
+
+- **scope:** Description (short-hash)
+
+### Added
+
+- Description (short-hash)
+
+### Fixed
+
+- Description (short-hash)
+```
+
+Rules:
+- Use today's date unless the user specifies otherwise
+- Include the 7-char short commit hash in parentheses
+- Capitalize the first letter of each description
+- If commits were skipped or flagged uncertain, add a note at the bottom:
+  ```markdown
+  > **Note:** {N} commits were skipped (vague messages). {M} classifications are uncertain — review entries marked with (?).
+  ```
+
+---
+
+## Step 5: Present and Write
+
+1. Show the generated changelog to the user
+2. If any uncertain classifications exist, list them and ask for corrections
+3. Ask: "Write this to CHANGELOG.md?"
+4. If CHANGELOG.md exists, insert the new version entry below the `# Changelog` header and above existing entries
+5. If CHANGELOG.md does not exist, create it:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [VERSION] - YYYY-MM-DD
+
+(entries here)
+```
+
+---
+
+## Common Mistakes
+
+- **Duplicating breaking changes** — a `feat!:` commit goes in Breaking Changes only, not also in Added
+- **Wrong commit range** — always verify the ref exists before using it as a range boundary
+- **Overwriting existing entries** — prepend new versions, never replace the file
+- **Missing body breaking changes** — check commit bodies, not just subjects, for `BREAKING CHANGE:` footers
+- **Over-classifying freeform commits** — when in doubt, put it in Other and flag it, rather than guessing wrong
+- **Including noise commits** — skip WIP, temp, fixup commits; they are not changelog-worthy
+- **Silently defaulting to all history** — on untagged repos, always confirm the range with the user first
+
+## Edge Cases
+
+- **No tags exist** — offer range options (date, count, branch), do not silently use all history
+- **No conventional commits** — use intelligent classification, flag uncertain items
+- **Monorepo** — if the user specifies a path filter, use `git log -- path/` to scope commits
+- **Empty range** — tell the user "No changes found between X and Y"
+- **All commits are squash-merged** — warn about lost granularity, read diffs to classify
+- **Mixed conventions** — some commits conventional, some not. Parse what you can, classify the rest intelligently
+- **Extremely large ranges (500+ commits)** — warn the user, offer to summarize by category count first before generating full output

--- a/skills/changelog-automation/examples/sample-output.md
+++ b/skills/changelog-automation/examples/sample-output.md
@@ -1,0 +1,127 @@
+# Example: Structured Repo (Conventional Commits + Tags)
+
+## Repo Assessment
+
+> **Repo assessment:** Found 12 tags, 28/30 recent commits follow conventional format.
+> Using **Structured** mode.
+
+## Input
+
+Git log between `v1.2.0` and `HEAD`:
+
+```
+a1b2c3d feat(auth): add OAuth2 provider support
+b2c3d4e feat(api): add pagination to list endpoints
+c3d4e5f fix: resolve memory leak in connection pool
+d4e5f6g fix(auth): fix token refresh race condition
+e5f6g7h perf: optimize database query batching
+f6g7h8i docs: update API reference for v2 endpoints
+g7h8i9j refactor: extract validation middleware
+h8i9j0k feat!: change default response format to JSON:API
+i9j0k1l chore: update dependencies
+j0k1l2m ci: add automated release pipeline
+k1l2m3n style: apply consistent naming to handlers
+```
+
+## Output
+
+```markdown
+## [1.3.0] - 2026-04-16
+
+### Breaking Changes
+
+- Change default response format to JSON:API (h8i9j0k)
+
+### Added
+
+- **api:** Add pagination to list endpoints (b2c3d4e)
+- **auth:** Add OAuth2 provider support (a1b2c3d)
+
+### Fixed
+
+- Resolve memory leak in connection pool (c3d4e5f)
+- **auth:** Fix token refresh race condition (d4e5f6g)
+
+### Performance
+
+- Optimize database query batching (e5f6g7h)
+
+### Documentation
+
+- Update API reference for v2 endpoints (f6g7h8i)
+
+### Changed
+
+- Apply consistent naming to handlers (k1l2m3n)
+- Extract validation middleware (g7h8i9j)
+
+### Build
+
+- Add automated release pipeline (j0k1l2m)
+
+### Other
+
+- Update dependencies (i9j0k1l)
+```
+
+---
+
+# Example: Freeform Repo (No Conventions, No Tags)
+
+## Repo Assessment
+
+> **Repo assessment:** Found 0 tags, 2/30 recent commits follow conventional format.
+> Using **Freeform** mode.
+>
+> Freeform commits detected. I will read each commit and classify it by intent. Results may need light editing.
+
+User chose: "last 20 commits"
+
+## Input
+
+```
+l2m3n4o added google login button to signup page
+m3n4o5p fixed the bug where users got logged out randomly
+n4o5p6q WIP
+o5p6q7r cleanup
+p6q7r8s moved all the api routes into separate files
+q7r8s9t update
+r8s9t0u made the search way faster with elasticsearch
+s9t0u1v updated readme with new install steps
+t0u1v2w remove old payment gateway code (stripe v2)
+u1v2w3x .
+```
+
+## Output
+
+```markdown
+## [1.0.0] - 2026-04-16
+
+### Added
+
+- Add Google login button to signup page (l2m3n4o)
+
+### Fixed
+
+- Fix bug where users got logged out randomly (m3n4o5p)
+
+### Performance
+
+- Make search faster with Elasticsearch (r8s9t0u)
+
+### Documentation
+
+- Update README with new install steps (s9t0u1v)
+
+### Changed
+
+- Move all API routes into separate files (p6q7r8s)
+- Remove old payment gateway code — Stripe v2 (t0u1v2w) (?)
+
+### Other
+
+- Clean up (o5p6q7r)
+
+> **Note:** 2 commits were skipped (vague messages: "WIP", "."). 1 classification is uncertain — review entries marked with (?).
+> "Remove old payment gateway code" was classified as Changed, but may be a Breaking Change if the Stripe v2 API was public. Please verify.
+```


### PR DESCRIPTION
## Skill Information
- **Skill Name:** changelog-automation
- **Category:** 📚 Documentation & Automation
- **Repository:** https://github.com/wyktor33/changelog-automation
- **I am the author:** [x] Yes

## Summary

- Fills the **community-needed** gap for changelog generation in the Documentation & Automation category
- Skill adapts to any repo state — conventional commits or freeform, tagged or untagged
- Unique advantage over CLI tools (semantic-release, git-cliff, etc.): Claude intelligently classifies freeform commits by reading messages and diffs instead of ignoring them
- Includes a dev cycle guide teaching teams how to maintain commit hygiene for better changelogs
- Documents complementary skills from obra/superpowers that improve output quality

## What's included

| File | Purpose |
|------|---------|
| `skills/changelog-automation/SKILL.md` | Core skill — 4-mode repo assessment, conventional + freeform parsing, Keep a Changelog output |
| `skills/changelog-automation/README.md` | Usage guide, 5-level dev cycle guide, complementary skills table, FAQ |
| `skills/changelog-automation/examples/sample-output.md` | Two full examples: structured repo + freeform repo |
| `README.md` | Updated listing from "Community-needed" to actual skill entry |

## Quality Checklist
- [x] Has working SKILL.md file with YAML frontmatter
- [x] Clear documentation (README with usage, dev cycle guide, FAQ)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements
- [x] Alphabetically sorted within category

## Test plan
- [ ] Install skill via `git clone` into `~/.claude/skills/`
- [ ] Invoke `/changelog-automation` in a repo with conventional commits + tags
- [ ] Invoke `/changelog-automation` in a repo with freeform commits and no tags
- [ ] Verify repo assessment correctly detects mode
- [ ] Verify freeform commits are intelligently classified
- [ ] Verify output follows Keep a Changelog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)