### PR TITLE
Add OpenAccountants to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Create charts, graphs, and interactive visualizations from datasets.
 **Use Case:** Data exploration, reporting, presentation of insights
 
+#### openaccountants
+**Source:** [openaccountants/openaccountants](https://github.com/openaccountants/openaccountants) | **Verified:** ⏳
+**Description:** Classify bank transactions by VAT category across 134 countries and prepare tax return working papers.
+**Use Case:** VAT classification, tax returns, transaction categorization from bank statements
+**Stars:** ⭐⭐⭐
+
 #### sql-query-builder
 **Status:** Community-needed
 **Description:** Generate optimized SQL queries with proper indexing and performance tuning.


### PR DESCRIPTION
Adds OpenAccountants to the Skill Collections table.

**What it does:** 371 tax classification skills across 134 countries — VAT/GST, income tax, social contributions. Bank statement classifier with conservative defaults and structured working paper outputs.

**Repository:** https://github.com/openaccountants/openaccountants