### PR TITLE
Add buyer-eval to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Content creation, marketing materials, company communications
 **Stars:** ⭐⭐⭐⭐
 
+#### buyer-eval
+**Source:** [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) | **Verified:** ⏳
+**Description:** Structured vendor evaluations with identical buyer criteria, side-by-side scorecards, and evidence citations.
+**Use Case:** Procurement decisions, vendor comparisons, RFP evaluation, build-vs-buy analysis
+**Stars:** ⭐⭐⭐⭐
+
 #### internal-comms
 **Source:** Community | **Verified:** ⏳
 **Description:** Draft internal communications, memos, and team announcements.

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Content creation, marketing materials, company communications
 **Stars:** ⭐⭐⭐⭐
 
-#### buyer-eval
+#### buyer-eval-skill
 **Source:** [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) | **Verified:** ⏳
 **Description:** Structured vendor evaluations with identical buyer criteria, side-by-side scorecards, and evidence citations.
 **Use Case:** Procurement decisions, vendor comparisons, RFP evaluation, build-vs-buy analysis


### PR DESCRIPTION
## Skill Information
- **Skill Name:** buyer-eval
- - **Category:** ✍️ Writing & Research
- - **Repository:** https://github.com/salespeak-ai/buyer-eval-skill
- - **I am the author:** [x] Yes
## Quality Checklist
- [x] Has working SKILL.md file
- [ ] - [x] Clear documentation
- [ ] - [x] Active maintenance (commits in last 6 months)
- [ ] - [x] Relevant to Claude workflows (Code/Web/API)
- [ ] - [x] No security issues
- [ ] - [x] Follows format requirements
- [ ] - [x] Alphabetically sorted within category
## Additional Context
buyer-eval is an open-source Claude Code skill for running structured vendor evaluations — applies identical buyer criteria across competing vendors and produces evidence-cited scorecards. 55+ stars, MIT licensed. Used by teams making procurement and build-vs-buy calls. Alphabetically placed between brand-guidelines and internal-comms in the Writing & Research section.