### PR TITLE
Add idea-os to Collaboration & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large refactors, multi-step implementations
 **Stars:** ⭐⭐⭐⭐
 
+#### idea-os
+**Source:** [Slashworks-biz/idea-os](https://github.com/Slashworks-biz/idea-os) | **Verified:** ✅
+**Description:** Five-phase pipeline turning a raw idea into questions, research, PRD, and phased plan.
+**Use Case:** Non-technical founders, PMs, or hobbyists with an idea and no structured path to build-ready artifacts.
+**License:** MIT
+
 ---
 
 ### ⚙️ Development & Architecture


### PR DESCRIPTION
**Skill:** idea-os
**Repo:** https://github.com/Slashworks-biz/idea-os
**Category:** 🤝 Collaboration & Workflow
**License:** MIT
**Active maintenance:** Yes — repo created 2026-04-18, under active development.

### What it does
Transforms a rough problem statement into four build-ready artifacts: clarifying questions, deep research (market, competitors, SWOT, JTBD, distribution, insights), PRD (with non-goals and metrics), and a phased execution plan with user journey, platform/stack picks, and kill criteria.

### Why it's different
Not a PRD editor and not a prompt template. Multi-phase workflow where each phase feeds the next: research shapes the PRD, PRD shapes the plan, plan's kill criteria tie back to research insights. Depth scales with a two-axis classification (complexity × builder sophistication).

Closest neighbors: `brainstorming` and `writing-plans` (both in Collaboration & Workflow). idea-os sits downstream of brainstorming, upstream of writing code.

### Verified output
- `examples/example-notion-for-dog-trainers.md` (590 lines) — the calibration reference
- `examples/jee-prep/` — real JEE-prep-app dog-food run: 282-line research.md (sourced competitor data on BYJU's, PhysicsWallah, Allen), 170-line PRD with Hinglish positioning, 272-line plan with Android-first Expo+Supabase+Claude stack

### Claude compatibility
- [x] Claude Code (primary)
- [x] Claude.ai (project skill)
- [x] Claude API (skills endpoint)