### PR TITLE
Add ChatCrystal skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [ChatCrystal](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) | 3 | @ZengLiangYi | Local-first memory recall and writeback for AI coding sessions |
 
 ---
 


### PR DESCRIPTION
## Skill Information
- **Skill Name:** ChatCrystal
- **Category:** Skill Collections
- **Repository:** https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills
- **I am the author:** Yes

## Quality Checklist
- [x] Has working SKILL.md file
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements

## Additional Context
ChatCrystal provides three local-first memory skills for AI coding sessions: task recall, debug recall, and task writeback. The public repo is installable and exposes these skills via `npx skills add ZengLiangYi/ChatCrystal --list`.