### PR TITLE
Add prompt-to-asset (Media & Content) and unslop (Writing & Research)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Creative coding, data visualization, generative design
 **Stars:** ⭐⭐⭐
 
+#### prompt-to-asset
+**Source:** [MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | **Verified:** ⏳
+**Description:** MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models.
+**Use Case:** App icons, OG images, favicons, brand logos — zero API key for first run via free-tier providers
+**Stars:** ⭐⭐⭐
+
 #### video-editing-helper
 **Status:** Community-needed
 **Description:** Assist with video editing workflows, ffmpeg commands, and transitions.
@@ -419,6 +425,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Status:** Community-needed
 **Description:** Gather, synthesize, and cite sources for research projects.
 **Use Case:** Academic research, market analysis, competitive intelligence
+
+#### unslop
+**Source:** [MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop) | **Verified:** ⏳
+**Description:** Removes named AI writing tells from text: tricolons, em-dash pileups, hedging stacks, sycophancy openers, overused vocab like "delve" and "crucial". Lint-only mode audits without rewriting.
+**Use Case:** Post-processing AI-generated copy, docs, and comms to remove robotic patterns
+**Stars:** ⭐⭐⭐
 
 #### technical-writing
 **Status:** Community-needed


### PR DESCRIPTION
## Add prompt-to-asset and unslop

Two community skill additions — one for image asset generation, one for AI writing quality.

### 1. prompt-to-asset — Media & Content Creation

[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) is an MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models. Selects the best-fit model per prompt automatically. Zero API key for first run via Pollinations, Stable Horde, and HuggingFace free tiers. Added before the community-needed video-editing-helper entry.

### 2. unslop — Writing & Research

[unslop](https://github.com/MohamedAbdallah-14/unslop) removes named AI writing tells from text: tricolons, em-dash pileups, hedging stacks, sycophancy openers, and overused vocabulary like "delve" and "crucial". Lint-only mode reports every flagged pattern without rewriting. Five intensity levels. Added before the community-needed technical-writing entry.

**Licenses:** both MIT
