### PR TITLE
Add master-skill to Meta Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large-scale refactoring, parallel development streams
 **Stars:** ⭐⭐⭐⭐⭐
 
+#### master-skill
+**Source:** [voidborne-d/master-skill](https://github.com/voidborne-d/master-skill)
+**Description:** A skill that *generates* domain-expert skills. Input a sub-niche industry; runs a 6-track research pipeline (practitioners, tool stack, workflows, canonical knowledge, information sources, terminology) and outputs a runnable `{industry}-master.skill` directory loadable into any Claude Code / Codex / OpenClaw / Hermes agent. Each generated skill ships with an Agentic Protocol so the agent searches facts first, then applies the industry's judgment heuristics — not encyclopedia lookup, but "how a senior in this field actually decides."
+**Use Case:** Equipping an agent to operate inside a vertical (RAG infra, e-commerce compliance, performance-marketing ROAS, etc.) without weeks of manual prompt-engineering. Third in the lineage colleague-skill (distill one person) → nuwa-skill (distill any thinking style) → master-skill (distill an entire field).
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ## Skill Collections


### PR DESCRIPTION
## What

Adds [voidborne-d/master-skill](https://github.com/voidborne-d/master-skill) to the **🎯 Meta Skills** category, alongside skill-creator and template-skill.

## Why it belongs in Meta Skills

The existing entries in this section operate on skills themselves (creating, sharing, testing, subagent-driven dev). master-skill operates one level above ordinary skills: you give it a sub-niche industry as input and it generates a runnable `{industry}-master.skill` directory — a domain-expert skill — as output.

So it's a meta-skill not because it teaches you to write skills (skill-creator already does that), but because skills are its output type.

## What it does in one paragraph

Input: an industry. Pipeline: Phase 0–5 (5 phases, 3 review gates, 30–60 min) running 6 parallel research tracks — practitioners, tool stack, workflows, canonical knowledge, information sources, terminology. Output: a self-contained skill directory loadable into any Claude Code / Codex / OpenClaw / Hermes agent. Each generated skill ships with an Agentic Protocol so the loaded agent searches facts first, then applies the industry's judgment heuristics — distilling *how a senior in the field decides*, not *what's in the field's wikipedia*.

## Checklist

- [x] Working `SKILL.md` with YAML frontmatter — [view](https://github.com/voidborne-d/master-skill/blob/main/SKILL.md)
- [x] Clear documentation — README in [中文](https://github.com/voidborne-d/master-skill/blob/main/README.md) / [English](https://github.com/voidborne-d/master-skill/blob/main/README_en.md)
- [x] Actively maintained — v1.1 released 2026-05-02 (bash command suite added)
- [x] Relevant to Claude workflows — designed to install into `~/.claude/skills/`, also runs on Codex / OpenClaw / Hermes
- [x] MIT license, no obfuscated code

## Lineage context (optional read)

master-skill is the third in a public lineage of distillation skills:
- [colleague-skill](https://github.com/titanwings/colleague-skill) — distill *one specific person*
- [nuwa-skill](https://github.com/alchaincyf/nuwa-skill) — distill *any thinking style* (Jobs, Munger, Musk, etc.)
- master-skill — distill *an entire industry's operating system*

Each layer is a 10× scope expansion. If the list eventually grows a "distillation" thread under Meta Skills, the three would naturally cluster — but for this PR I'm only proposing master-skill as a standalone Meta entry.

## Notes

- Self-rated 4 stars (no Verified ✅ badge requested — happy for that to land via the maintainer's verification pass when convenient).
- If a different category placement is preferred (e.g. its own "Skill Generators" subsection later), let me know and I'll revise.