### PR TITLE
Add cowork-tasks to Collaboration & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 🤝 Collaboration & Workflow
 
+#### cowork-tasks
+**Source:** [sabbah13/cowork-tasks](https://github.com/sabbah13/cowork-tasks)
+**Description:** Kanban task manager plugin for Claude Cowork bundling 5 skills for chat capture, triage, coaching, and a live board artifact.
+**Use Case:** Capturing tasks from chat, on-demand triage from connected sources, daily coaching, and kanban tracking inside Claude Cowork.
+**Stars:** ⭐⭐⭐
+
 #### requesting-code-review
 **Source:** [obra/superpowers](https://github.com/obra/superpowers) | **Verified:** ✅
 **Description:** Pre-review preparation and PR best practices with formatted diffs.
@@ -475,6 +481,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [sabbah13/cowork-tasks](https://github.com/sabbah13/cowork-tasks) | 5 | @sabbah13 | Kanban task management & triage for Claude Cowork |
 
 ---
 


### PR DESCRIPTION
## Skill Information
- **Skill Name:** cowork-tasks
- **Category:** Collaboration & Workflow (+ Skill Collections row)
- **Repository:** https://github.com/sabbah13/cowork-tasks
- **I am the author:** [x] Yes

## Quality Checklist
- [x] Has working SKILL.md files (5 of them)
- [x] Clear documentation
- [x] Active maintenance (commits within last week)
- [x] Relevant to Claude workflows (Cowork)
- [x] No security issues
- [x] Follows format requirements
- [x] Alphabetically sorted within category

## Additional Context

Cowork Tasks is the first kanban task manager built for Claude Cowork. The plugin ships 5 skills (open-board, triage-now, new-task, coach-me, setup), plus a /health diagnostic and a task-extractor agent. MIT-licensed.

Following PR #11 (pm-skills) and PR #35 (shipwise) precedent of registering a multi-skill plugin as a single entry plus a row in the Skill Collections table.