### PR TITLE
Add claude-persona to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Content creation, marketing materials, company communications
 **Stars:** ⭐⭐⭐⭐
 
+#### claude-persona
+**Source:** [takechanman1228/claude-persona](https://github.com/takechanman1228/claude-persona) | **Verified:** ⏳
+**Description:** Build AI persona panels and pressure-test concepts with agent-separated simulation, then synthesize themes, cross-tabs, and verbatims into a research report
+**Use Case:** Pre-fieldwork qualitative research, concept/message/packaging tests, persona-driven copy and feature decisions
+**Stars:** ⭐⭐⭐
+
 #### internal-comms
 **Source:** Community | **Verified:** ⏳
 **Description:** Draft internal communications, memos, and team announcements.


### PR DESCRIPTION
Adds [claude-persona](https://github.com/takechanman1228/claude-persona) to the **Writing & Research** section.

**What it does**: A Claude Code skill for AI persona panels and concept testing. Inspired by Microsoft's [TinyTroupe](https://github.com/microsoft/TinyTroupe).

- `/persona generate` — reusable panels with diverse demographics, Big Five traits, and segment balance
- `/persona ask` — open-ended interviews on motivations, barriers, decision criteria
- `/persona concept-test` — structured A/B/C comparison of messages, offers, or features
- Each persona runs in its own `claude -p` subprocess (agent-separated, no shared context, no groupthink)
- Output: executive report with theme synthesis, cross-tabs, charts, and verbatims

**Why Writing & Research**: The primary use case is qualitative research — exploring motivations, testing copy, and pressure-testing concepts — which fits alongside `brand-guidelines`, `internal-comms`, and `research-assistant` better than Data & Analysis.

**Links**:
- Repo: https://github.com/takechanman1228/claude-persona
- License: MIT
- SKILL.md at `skills/persona/SKILL.md`
- Installable via `/plugin marketplace add takechanman1228/claude-persona`
- Four bundled demos (Gen Z skincare, premium chocolate, RTD soda, sneakers) with pre-generated panels and full results

Happy to adjust wording or section if Data & Analysis fits the list better.