### PR TITLE
Add news-sentiment-engine to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Parse, transform, and analyze CSV files with data cleaning and validation.
 **Use Case:** Data migration, ETL processes, data quality checks
 
+#### news-sentiment-engine
+**Source:** [tellmefrankie/news-engine](https://github.com/tellmefrankie/news-engine) | **Verified:** ✅
+**Description:** Collect AI/tech news from 4+ RSS feeds, deduplicate, rank by impact, and generate sentiment-tagged summaries.
+**Use Case:** Daily tech briefings, investment signals, media monitoring, Slack/Telegram news bots
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### ✍️ Writing & Research


### PR DESCRIPTION
## Skill Submission

**Skill name:** news-sentiment-engine
**Category:** Data & Analysis
**Source:** https://github.com/tellmefrankie/news-engine

## Description

Collects AI/tech news from 4+ RSS feeds (TechCrunch, The Verge, Ars Technica, Hacker News), deduplicates articles across sources, ranks by industry impact score, and generates sentiment-tagged summaries via Claude. Output includes Korean-language briefing cards with sentiment (positive/negative/neutral), impact score (1-5), and industry tags.

## Use Cases

- Daily AI/tech briefings via Telegram or Slack bots
- Investment signal detection (tech sector sentiment)
- Media monitoring and trend tracking
- Automated newsletter generation

## Quality Checklist

- [x] Working SKILL.md with valid content
- [x] Clear documentation — purpose, usage, and output format documented
- [x] Actively maintained (production use since 2026, 50+ articles/day)
- [x] Claude-powered (uses Claude API for analysis and summarization)
- [x] No malicious code — open source, MIT licensed
- [x] Description under 150 characters
- [x] Valid, tested GitHub link

🤖 Submitted via Claude Code (claude-sonnet-4-6)