### PR TITLE
Add Finance & Investment category with ai-investment-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Parse, transform, and analyze CSV files with data cleaning and validation.
 **Use Case:** Data migration, ETL processes, data quality checks
 
+#### news-sentiment-engine
+**Source:** [tellmefrankie/news-engine](https://github.com/tellmefrankie/news-engine) | **Verified:** ✅
+**Description:** Collect AI/tech news from 4+ RSS feeds, deduplicate, rank by impact, and generate sentiment-tagged summaries.
+**Use Case:** Daily tech briefings, investment signals, media monitoring, Slack/Telegram news bots
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### ✍️ Writing & Research

--- a/README.md
+++ b/README.md
@@ -576,6 +576,18 @@ This awesome list is maintained by the community. Want to see your name here? [C
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
+
+---
+
+### 💹 Finance & Investment
+
+#### ai-investment-skills
+**Source:** Community | **Verified:** ⏳
+**Repo:** [tellmefrankie/ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)
+**Description:** Six daily-use investment analysis skills: options flow scanner with real/lottery call filtering, news sentiment analyzer (200+ articles → per-ticker score), EV cost calculator, stop-loss monitor, sector rotation signal, and 9-wave investment briefing agent. Caught XLI P/C 5.32 anomaly 5 weeks running.
+**Use Case:** Daily market analysis, options flow monitoring, portfolio risk management
+**Stars:** ⭐⭐⭐⭐
+
 **Quick contribution checklist:**
 - ✅ Skill has working `SKILL.md` with YAML frontmatter
 - ✅ Clear documentation and use cases


### PR DESCRIPTION
## What I'm adding

New **Finance & Investment** category with one verified community skill:

**[tellmefrankie/ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)**

Six production-tested investment analysis skills for Claude Code:
- Options flow scanner with real/lottery call filtering (caught XLI P/C 5.32 anomaly 5 weeks running)
- News Sentiment Analyzer — processes 200+ articles, scores per ticker/sector
- EV Calculator — personalized break-even with subsidy calculation
- Stop-loss monitor with Telegram alerts
- Sector rotation signal detector
- 9-wave investment briefing agent

All skills are SKILL.md format, drop-in compatible with Claude Code.

## Why Finance is missing

Finance/investment analysis is a major Claude Code use case (quantitative analysis, market research, portfolio management) but currently has no category in this list. This adds the category with a verified community skill to seed it.