### PR TITLE
Add claude-memory-manager to Meta Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large-scale refactoring, parallel development streams
 **Stars:** ⭐⭐⭐⭐⭐
 
+#### claude-memory-manager
+**Source:** [jau123/claude-memory-manager](https://github.com/jau123/claude-memory-manager)
+**Description:** Schema + audit on top of Claude Code's auto-memory; flags drift before the library becomes unsearchable.
+**Use Case:** Long-running Claude Code projects where the memory library has grown past a few dozen files
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ## Skill Collections


### PR DESCRIPTION
Adding a new skill to the Meta Skills category:

- **Repo**: https://github.com/jau123/claude-memory-manager
- **What it does**: Sits on top of Claude Code's built-in auto-memory (v2.1.59+). Enforces a 3-type schema (`feedback` / `reference` / `project`), required frontmatter (`name` / `description` / `type`), and a Why section on `feedback` entries. A bash audit script flags drift: missing fields, oversized files, orphan entries.
- **Why Meta**: It governs how Claude writes memory, rather than performing a domain-specific task.
- **Use case**: Long-running Claude Code projects where the memory library has passed a few dozen files and is becoming unsearchable.

### Quality criteria (per CONTRIBUTING.md)

- ✅ Valid `SKILL.md` with YAML frontmatter (name / description)
- ✅ Documentation: README + INSTALL + references/{design-philosophy, schema, audit-tool-guide} + 3 example entries
- ✅ Claude relevance: 100% — Claude Code skill
- ✅ Active maintenance: committed today
- ✅ Open source: MIT
- ✅ No malicious code: single `SKILL.md` + one bash audit script

I left `Stars: ⭐⭐⭐⭐` self-assessment; please adjust as you see fit.