### PR TITLE
Add recsys-pipeline-architect (Development & Architecture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Code smell detection and systematic refactoring techniques.
 **Use Case:** Legacy code modernization, improving code quality
 
+#### recsys-pipeline-architect
+**Source:** [mturac/recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) | **Verified:** ✅
+**Description:** Designs composable recommendation, ranking, and feed pipelines using the six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework popularized by xAI's open-sourced X For You algorithm. Surfaces architectural trade-offs (multi-action vs single-score, candidate isolation vs joint, online vs offline batch) explicitly; ships 3 runnable scaffolds (Strapi/TS, Go, Python/FastAPI — 9/9 tests passing).
+**Use Case:** For-you feeds, RAG retrieval rerankers, task prioritizers, notification triage, search reranking, ad ranking
+**Stars:** ⭐⭐⭐
+
 ---
 
 ### 🔒 Security & Performance


### PR DESCRIPTION
Adds [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) under *Development & Architecture*.

A vendor-agnostic Agent Skill (agentskills.io standard) for designing composable recommendation, ranking, and feed pipelines using the six-stage **Source → Hydrator → Filter → Scorer → Selector → SideEffect** framework popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm). MIT, independent reimplementation of the pattern.

Repo: SKILL.md + 5 load-on-demand reference docs (interfaces in 4 languages, multi-action scoring, candidate isolation, filter cookbook with 12 patterns, scorer cookbook) + 3 runnable example scaffolds (Strapi v5/TS, Go with generics, Python/FastAPI — 9/9 tests passing). v0.1.0 release tagged.

Cross-platform install via skills.sh: `npx skills add mturac/recsys-pipeline-architect` (covers Claude Code, Codex CLI, Cursor, Gemini CLI + 13 more agents).