### PR TITLE
Add winston-coach to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Create clear technical documentation following industry best practices.
 **Use Case:** API docs, user manuals, technical specifications
 
+#### winston-coach
+**Source:** [Anastasios3/winston-coach](https://github.com/Anastasios3/winston-coach) | **Verified:** ⏳
+**Description:** Apply Patrick Winston's MIT framework (How to Speak + Make It Clear) to any writing or speaking task. Mandatory humanizer pass strips AI tells from every written output.
+**Use Case:** Talks, decks, reports, emails, pitches, papers, abstracts, job talks — anywhere clear, persuasive, undetectable-as-AI communication matters.
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### 🎯 Meta Skills


### PR DESCRIPTION
Adds **winston-coach** — a Claude skill that applies Patrick Winston's framework from MIT's "How to Speak" lecture and his book *Make It Clear: Speak and Write to Persuade and Inform* to any writing or speaking task.

**What it does**
- 14 Winston tools: Empowerment Promise, VSN-C structure (Vision-Steps-News-Contributions), Winston's Star (Symbol-Slogan-Surprise-Salient-Story), the four engagement heuristics, slide hygiene, six standard openings for written work, the abstract checklist, broken-glass outline, surface clues for skimmers, plus format-specific guidance.
- Routes by format: talks, decks, reports, memos, emails, blog posts, pitches, recommendation letters, abstracts, press releases, papers, more.
- Mandatory humanizer pass on every written output — strips em-dash overuse, AI vocabulary, copula avoidance, synonym cycling, fake parallelisms, the usual tells.
- Eats its own dog food: the skill content itself avoids the patterns it strips.

**Why it might be useful**
Winston's "How to Speak" has ~19M views on YouTube and is widely cited but rarely applied consistently. Packaging the framework as a Claude skill means it auto-applies on every writing or speaking task without having to re-read the source. The skill also corrects several common popularization errors (e.g., "salient" means *sticks out*, not *important*; the book co-author is Karen Prendergast not "Prensky"; the book was finished by Winston himself in 2020, not posthumously by someone else).

**Repo:** https://github.com/Anastasios3/winston-coach
**License:** CC BY-NC-SA 4.0
**Working SKILL.md with YAML frontmatter:** yes
**Author:** [@Anastasios3](https://github.com/Anastasios3)

Happy to adjust the entry placement or wording if needed.
