### PR TITLE
Add building-blog to Development & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Code smell detection and systematic refactoring techniques.
 **Use Case:** Legacy code modernization, improving code quality
 
+#### building-blog
+**Source:** [BuildShipGrowRepeat/nextjs-sanity-blog-skill](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill) | **Verified:** ✅
+**Description:** Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via 40-question intake, one-page plan, and a 20-section spec.
+**Use Case:** Blog scaffolding, Sanity schema design, hreflang/JSON-LD setup, AI hero images via Gemini 3 Pro Image
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### 🔒 Security & Performance


### PR DESCRIPTION
Adds the `building-blog` skill under **⚙️ Development & Architecture**.

- **Source:** https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill
- **What it does:** Walks 40 intake questions, scans the host project, drafts a one-page plan for approval, then implements an SEO-first, i18n-ready blog on Next.js + Sanity against a 20-section spec with a pass/fail checklist.
- **Why it's useful:** Most "add a blog to my Next.js site" prompts ship with missing hreflang, no JSON-LD, no alt-text discipline, or over-engineered i18n. This skill bakes the opinions in once and exposes the overrides via the intake.
- **License:** MIT, active.