### PR TITLE
Add Skill Locker to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Looking for curated skill bundles? Start with these collections:
 | [ChatCrystal](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) | 3 | @ZengLiangYi | Local-first memory recall and writeback for AI coding sessions |
 | [Affitor/affiliate-skills](https://github.com/Affitor/affiliate-skills) | 45 | @Affitor | Affiliate marketing full funnel: research, content, SEO, landing pages, distribution, analytics, automation |
 | [noizai/skills](https://github.com/noizai/skills) | 2+ | @noizai | TTS dubbing and companion voice presets |
+| [Skill Locker](https://skilllocker.ai) | 296 | @miniminer-droid | Non-developer-first: business, marketing, career, course creation, health, agency ops, fundraising |
 
 ---
 


### PR DESCRIPTION
Adds [Skill Locker](https://skilllocker.ai) to the Skill Collections table.

**What it is:** a paid Claude Code skill marketplace with 296 hand-authored skills across 33 categories, leaning non-developer-first (business, marketing, career, course creation, health & wellness, agency ops, fundraising, community building, personal brand, etc. — categories the existing free collections cover lightly or not at all).

**Quality signals:**
- Every skill has a dedicated landing page with description, when-it-triggers, and an example
- All skills are v1.3.0 — each has been through 3 Karpathy-loop improvement cycles
- Catalog metadata is published as a free public dataset at https://skilllocker.ai/skills.json for tools/research/comparison sites

Happy to revise wording, drop irrelevant fields, or omit if it's not a fit. Thanks for maintaining this list.