### PR TITLE
Add docs-to-book to Document & File Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Automated slide generation, presentation analysis, template customization
 **Stars:** ⭐⭐⭐⭐
 
+#### docs-to-book
+**Source:** [EliaTolin/docs-to-book-skills](https://github.com/EliaTolin/docs-to-book-skills) | **Verified:** ❓
+**Description:** Crawl an online technical documentation site and turn it into a colorful, readable PDF book, translated into the language of your choice.
+**Use Case:** Studying docs offline, building a printable manual or ebook from a documentation website
+
 ---
 
 ### 🧪 Testing & Quality


### PR DESCRIPTION
Adds **docs-to-book** under *📄 Document & File Processing*.

[docs-to-book](https://github.com/EliaTolin/docs-to-book-skills) crawls an online technical documentation site and turns it into a colorful, readable PDF book, translated into the language of your choice.

**Quality criteria**
- Valid `SKILL.md` with YAML frontmatter (name + description) and clear When-to-Use triggers.
- More than a single file: ships `scripts/` (crawl, extract, brand extraction, Typst compile), `references/` (crawling strategy, tone guide, integrity rules, Typst callouts), `assets/` (Typst styles + cover), and `evals/`.
- Open source, MIT licensed, actively maintained.

I marked **Verified: ❓** since I'm the author — feel free to verify and flip it.