### PR TITLE
Add regulex-plus to Development & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Code smell detection and systematic refactoring techniques.
 **Use Case:** Legacy code modernization, improving code quality
 
+#### regulex-plus
+**Source:** [PipeDream941/regulex-plus](https://github.com/PipeDream941/regulex-plus) | **Verified:** ✅
+**Description:** Renders JavaScript regex as railroad-style SVG/PNG diagrams via a Playwright-driven CLI. Native CJK/Chinese support, dark/light themes, npm-published.
+**Use Case:** Explaining or debugging complex regex (alternations, lookarounds, quantifiers), verifying AI-generated regex before merging, documenting regex in PRs/docs with inline images
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### 🔒 Security & Performance


### PR DESCRIPTION
Adds [regulex-plus](https://github.com/PipeDream941/regulex-plus) to the **Development & Architecture** category.

## What it does

Renders any JavaScript regex as a railroad-style SVG/PNG diagram via a Node CLI. Wraps the regulex-plus web visualizer with Playwright so it works in any Node environment without manual screenshots.

```bash
npx regulex-plus '^(\\d{3})-(\\d{4})$' --out phone.png
npx regulex-plus '中文(标点|符号)+' --theme dark --out cjk.png
```

## Why it fits "Verified ✅"

- **Working SKILL.md** at repo root with proper YAML frontmatter (name + description). Verified via local install on Claude Code.
- **Live demo** at https://pipedream941.github.io/regulex-plus/ — anyone can confirm the rendering quality before installing.
- **Tested across patterns**: ASCII (`^(a|b)*?$`), CJK (`中文(标点|符号)+`), quantifiers (`\\d{3}-\\d{4}`), invalid input (proper error exit).
- **MIT-licensed** fork of CJex/regulex with active maintenance (CJK width fixes, PNG export fix, i18n, dark theme).

## Use cases

- Explaining complex regex during pair-programming or code review
- Debugging catastrophic-backtracking or unintended alternations
- Verifying AI-generated regex visually before merging
- Documenting regex in PRs/docs with inline diagram images
- CJK / Chinese character regex (the differentiator vs other visualizers)

Happy to adjust the entry format or move it to a different category if you prefer.