### PR TITLE
Add doc2math to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Status:** Community-needed
 **Description:** Parse, transform, and analyze CSV files with data cleaning and validation.
 **Use Case:** Data migration, ETL processes, data quality checks
+#### doc2math
+**Source:** [thebrierfox/doc2math-skill](https://github.com/thebrierfox/doc2math-skill) | **Verified:** ⏳
+**Description:** Extract and formalize mathematical structures, formulas, and equations from documents into structured notation.
+**Use Case:** Research paper analysis, technical documentation, formula extraction, academic workflows
+**Stars:** ⭐⭐⭐⭐
 
 ---
 


### PR DESCRIPTION
## New Skill: doc2math

**Source:** [thebrierfox/doc2math-skill](https://github.com/thebrierfox/doc2math-skill)

**Description:** Extract and formalize mathematical structures, formulas, and equations from documents into structured notation. Converts natural-language math descriptions into LaTeX, MathML, or symbolic form.

**Category:** 📊 Data & Analysis

**Use Case:** Research paper analysis, technical documentation, formula extraction, academic workflows

---

This skill enables Claude to systematically parse documents for implicit or explicit mathematical content and render it in precise, reusable form — useful for researchers, engineers, and technical writers.
