### PR TITLE
Add Pathmode Skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [pathmodeio/claude-code-skills](https://github.com/pathmodeio/claude-code-skills) | 7 | @pathmodeio | Product intent engineering & spec authoring |
 
 ---
 


### PR DESCRIPTION
Adds **pathmodeio/claude-code-skills** to the Skill Collections table.

**What's in the pack:** 7 auto-triggering Claude Code skills for product intent — compile-intent, grill-intent, verify-intent, review-against-intent, split-intent-to-issues, handoff-intent, and setup-pathmode-workflow.

**Per the contributing checklist:**
- ✅ Each skill has a working `SKILL.md` with YAML frontmatter (`name` + `description`)
- ✅ Actively maintained — v1 shipped this week (June 2026)
- ✅ MIT-licensed, no security issues
- ✅ Format matches `mattpocock/skills` exactly: `<what-to-do>` + `<supporting-info>` blocks

**Install:** `npx @pathmode/mcp-server install-skills`

Placed in **Skill Collections** rather than as individual entries in **Meta Skills** because Pathmode is a bundle covering a single product-intent workflow, similar to how `obra/superpowers` and `anthropics/skills` are listed there.