### PR TITLE
docs: add Claude Skills 中文市集 to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [Claude Skills 中文市集](https://claudeskill.me) | 104+ | [@fanshanhong](https://github.com/fanshanhong/claude-skills-cn) | Chinese-language deep-dive articles covering superpowers, oh-my-claudecode, ecc, gstack and more |
 
 ---
 


### PR DESCRIPTION
Adding a Chinese-language Skills resource to broaden geographic coverage of this list.

- Site: https://claudeskill.me
- 104+ articles, each covering one Claude Code Skill in depth
- Suites covered: superpowers, oh-my-claudecode, ecc, gstack, and more
- Content: AI-generated + human-audited; every article has a mermaid flowchart
- Open source: https://github.com/fanshanhong/claude-skills-cn

I followed the CONTRIBUTING guidelines (active maintenance, clear use case, community-curated). Happy to adjust if placement should differ.