### PR TITLE
Add SEO & Content Marketing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,16 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ---
 
+### 🔍 SEO & Content Marketing
+
+#### easetoolz-seo
+**Source:** [ariarihantmedia-bit/easetoolz-seo-skill](https://github.com/ariarihantmedia-bit/easetoolz-seo-skill) | **Verified:** ⏳
+**Description:** Universal SEO + GEO skill for Claude Code. Technical audit, competitor gap analysis, schema generation, blog writing (Hindi+English), SERP clustering, AI search optimization. Built for tool sites & SaaS.
+**Use Case:** SEO audits, content strategy, competitor analysis, schema markup, local SEO India
+**Stars:** ⭐⭐⭐⭐⭐
+
+---
+
 ### 🎯 Meta Skills
 
 #### skill-creator


### PR DESCRIPTION
## Skill Information

- **Skill Name:** easetoolz-seo
- **Category:** SEO & Content Marketing
- **Repository URL:** https://github.com/ariarihantmedia-bit/easetoolz-seo-skill
- **I am the author of this skill:** [x] Yes

## Quality Checklist

- [x] SKILL.md file exists with proper YAML frontmatter
- [x] Clear description and use cases documented
- [x] MIT license included
- [x] README with install instructions
- [x] 9 sub-skills: audit, geo, schema, content, writing, local, cluster, competitor
- [x] Supports Hindi + English
- [x] WASM/tool site specific SEO rules
- [x] Free, open-source
