### PR TITLE
Add clone-team (Development & Architecture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Interactive demos, prototypes, data visualizations
 **Stars:** ⭐⭐⭐⭐
 
+#### clone-team
+**Source:** [Varalix-Digitech-Solutions/clone-team](https://github.com/Varalix-Digitech-Solutions/clone-team)
+**Description:** Multi-agent team that clones any website into a pixel-perfect UI in your stack, plus reverse-engineered architecture docs.
+**Use Case:** Exact UI clones in React/Vue/Svelte behind an unskippable test gate, plus an ARCHITECTURE.md to rebuild the site
+**Stars:** ⭐⭐⭐
+
 #### api-development
 **Status:** Community-needed
 **Description:** RESTful API design patterns with OpenAPI/Swagger generation.


### PR DESCRIPTION
## Adding: clone-team

**Repo:** https://github.com/Varalix-Digitech-Solutions/clone-team · **License:** MIT

A Claude Code skill that orchestrates a team of agents — Manager, Frontend Developer, Backend Architect, Tester — to clone any website into a **pixel-perfect UI** in the stack *you* choose (React/Vue/Svelte/HTML…) **and** produce a reverse-engineered **ARCHITECTURE.md** of how the site works.

What makes it different: the build/test loop is a deterministic Workflow with an **unskippable Tester gate** — a section isn't 'done' until a full visual + behavioral regression passes, so the model can't declare half-finished work complete. It also sizes its agent fan-out to the host's RAM and is fully pausable/resumable across sessions.

### Meets the contribution criteria
- ✅ Open-source, real implementation (not a SaaS wrapper / no server-side calls beyond the Anthropic API the agents already use)
- ✅ Actively maintained — committed this week
- ✅ Installable + uninstallable (Claude Code plugin: `/plugin marketplace add Varalix-Digitech-Solutions/clone-team` → `/plugin install clone-team@clone-team`; or manual skill copy)
- ✅ Demos: side-by-side case study at https://clone-team.varalix.com

Added under **⚙️ Development & Architecture**, matching the existing entry format. Rated ⭐⭐⭐ — newer project (it's a few days public) but with thorough docs and a working case study; happy to adjust the rating or placement if you'd prefer.