### PR TITLE
Add ltx2-vidgen-skill (self-hosted LTX-2.3 video) to Media & Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Creative coding, data visualization, generative design
 **Stars:** ⭐⭐⭐
 
+#### ltx2-vidgen-skill
+**Source:** [patraxo/ltx2-vidgen-skill](https://github.com/patraxo/ltx2-vidgen-skill) | **Verified:** ⏳
+**Description:** Self-hosted LTX-2.3 (22B) AI video, driven from Claude Code — deploys your own Modal serverless-GPU backend, then text/image/keyframe/video-to-video + IC-LoRA canny/depth/pose control, with synced audio.
+**Use Case:** Generate reels/shorts from a photo or prompt on your own GPU — a few cents a clip, no per-clip meter; batch many takes (`--variations N`) and keep the best.
+
 #### video-editing-helper
 **Status:** Community-needed
 **Description:** Assist with video editing workflows, ffmpeg commands, and transitions.


### PR DESCRIPTION
Adds **[ltx2-vidgen-skill](https://github.com/patraxo/ltx2-vidgen-skill)** under 🎬 Media & Content Creation, in the repo's per-skill block format.

A Claude Code skill that deploys your own LTX-2.3 (22B) video backend to your Modal serverless GPU, then generates from a photo or prompt — text/image/keyframe/video-to-video + IC-LoRA canny/depth/pose control, with synced audio. You own the GPU; a few cents a clip, no per-clip meter.

Meets the contribution checklist: working SKILL.md with YAML frontmatter ✓, clear use cases ✓, actively maintained ✓, Claude-relevant ✓, MIT, public, v1.0.0, CI-validated plugin manifest. Install: `npx skills add patraxo/ltx2-vidgen-skill` or `/plugin marketplace add patraxo/ltx2-vidgen-skill`. Marked Verified ⏳ (community).