### PR TITLE
feat: add CreatorSkills marketplace to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [CreatorSkills Marketplace](https://creatorskills.co) | 30+ | @creatorskills | Content creation skills for YouTube, sponsorships & repurposing (SKILL.md format, paid) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Skill Collections** section — a dedicated marketplace for AI skills targeting content creators.

**Why it belongs here:**
- Skills use the open **SKILL.md standard**, compatible with Claude Code, Claude.ai, and 20+ agent platforms
- Focused vertical: YouTube scripting, sponsorship analysis, content repurposing, audience growth
- 30+ skills available covering the full content creator workflow
- Installable via `npx skills add` like other listed collections

**Details:**
- Format: SKILL.md (same open standard as obra/superpowers and anthropics/skills)
- Pricing: paid marketplace ($9–$49 per skill)
- URL: https://creatorskills.co