### PR TITLE
Add game-build-team (Development & Architecture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Interactive demos, prototypes, data visualizations
 **Stars:** ⭐⭐⭐⭐
 
+#### game-build-team
+**Source:** [Varalix-Digitech-Solutions/game-build-team-skill](https://github.com/Varalix-Digitech-Solutions/game-build-team-skill)
+**Description:** Multi-agent team that builds Godot 4 / GDScript game features behind two unskippable gates — a headless test gate and an "is it fun" creative gate — then verifies on a real device.
+**Use Case:** Game features that arrive tested AND fun: gameplay logic + game-feel juice + real tests, resumable across usage-limit cutoffs
+**Stars:** ⭐⭐⭐
+
 #### api-development
 **Status:** Community-needed
 **Description:** RESTful API design patterns with OpenAPI/Swagger generation.


### PR DESCRIPTION
Adds **game-build-team** to Development & Architecture.

A Claude Code skill that builds Godot 4 / GDScript game features with a coordinated team of AI agents (Manager, Recon Analyst, Creative Director, Logic Developer, Animation Developer, Tester). The build/test loop is a deterministic Workflow program with two unskippable gates — a headless test gate (suite green, acceptance criteria asserted, screenshot vs the design contract) and an "is it fun" creative gate — capped by an on-device final pass. Pausable/resumable across sessions and usage-limit cutoffs.

- Repo: https://github.com/Varalix-Digitech-Solutions/game-build-team-skill
- Site: https://game-build-team.varalix.com/
- MIT licensed, installs as a Claude Code plugin in two commands.

Entry follows the section's existing format (Source/Description/Use Case/Stars).