### PR TITLE
Add seedance-prompts-skill to Media & Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Creative coding, data visualization, generative design
 **Stars:** ⭐⭐⭐
 
+#### seedance-prompts-skill
+**Source:** [mantoufan/seedance-prompts-skill](https://github.com/mantoufan/seedance-prompts-skill)
+**Description:** Turns an idea or novel into a short-drama screenplay, then into ready-to-use Seedance 2.0 video prompts and storyboards.
+**Use Case:** Producing AI short-drama / micro-film scripts and Seedance 2.0 video prompts at volume
+**Stars:** ⭐⭐⭐⭐
+
 #### video-editing-helper
 **Status:** Community-needed
 **Description:** Assist with video editing workflows, ffmpeg commands, and transitions.


### PR DESCRIPTION
Adds [seedance-prompts-skill](https://github.com/mantoufan/seedance-prompts-skill) under **🎬 Media & Content Creation**, following the format in CONTRIBUTING.md.

**What it does:** a Claude Skill (also works with ChatGPT / other LLMs) for AI video creation with ByteDance's Seedance 2.0 — turns an idea or novel into a full short-drama screenplay, then converts the screenplay/article/outline into copy-paste-ready Seedance 2.0 video prompts and audio-visual timeline storyboards via a progressive command flow (`/start /plan /characters /outline /episode /review /compliance /export`).

**Quality criteria:**
- ✅ Working `SKILL.md` with YAML frontmatter
- ✅ Clear, comprehensive bilingual docs (中文 + English)
- ✅ Claude-relevant (Claude Code / Claude.ai skill)
- ✅ Actively maintained (commits this week), open source