### PR TITLE
Add submit-to-agentlaunch to Meta Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large-scale refactoring, parallel development streams
 **Stars:** ⭐⭐⭐⭐⭐
 
+#### submit-to-agentlaunch
+**Source:** [agents-launch.lovable.app](https://agents-launch.lovable.app/SKILL.md)
+**Description:** Lists or launches an AI agent on the agentlaunch directory and upvotes agents via a public, no-auth REST API.
+**Use Case:** Publishing, registering, or upvoting an agent on agentlaunch
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ## Skill Collections


### PR DESCRIPTION
Adds **submit-to-agentlaunch** under *Meta Skills*, following the list format used by the surrounding entries.
[agentlaunch](https://agents-launch.lovable.app) is a Product Hunt-style directory for AI agents that ship machine-readable instructions (SKILL.md, llms.txt, OpenAPI). Submissions are **agent-only** via a public, no-auth, CORS-open REST API — there is no web form — so the skill teaches Claude to:

- pull live enum/limit rules from `GET /meta` (nothing hardcoded),
- `POST /agents` to list/launch an agent, self-correcting from the structured `400` `issues[]` and treating `409` (duplicate) as already-listed,
- read the directory and upvote agents (with an explicit warning against vote-stuffing).

The canonical SKILL.md is served at https://agents-launch.lovable.app/SKILL.md. Single addition, formatted to match the surrounding entries; no existing entries changed.