### PR TITLE
Add kpab/claude-fable-5-skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [kpab/claude-fable-5-skills](https://github.com/kpab/claude-fable-5-skills) | 10 | @kpab | Fable 5-native skills: effort calibration, scope guarding & subagent orchestration |
 
 ---
 


### PR DESCRIPTION
Adds **[kpab/claude-fable-5-skills](https://github.com/kpab/claude-fable-5-skills)** to the Skill Collections table.

A 10-skill collection written Fable 5-first — guardrails and verification hooks instead of the capability-compensation scaffolding older models needed. Each skill ships a valid `SKILL.md` (YAML frontmatter + Markdown body) and works across Claude Code, Cursor, Copilot, and Gemini CLI.

Highlights: effort calibration, scope guarding, no-gold-plating, grounded progress reporting, and fresh-context subagent orchestration.

- Open source (MIT), all 10 skills have SKILL.md with YAML frontmatter
- Actively maintained