### PR TITLE
Add corpspeak to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Content creation, marketing materials, company communications
 **Stars:** ⭐⭐⭐⭐
 
+#### corpspeak
+**Source:** [giorgiozamboni/corpspeak](https://github.com/giorgiozamboni/corpspeak) | **Verified:** ⏳
+**Description:** Rewrites text into corporate/C-suite register at three levels without sounding AI-generated.
+**Use Case:** Emails, decks, and LinkedIn posts; bilingual English and Italian
+**Stars:** ⭐⭐⭐⭐
+
 #### internal-comms
 **Source:** Community | **Verified:** ⏳
 **Description:** Draft internal communications, memos, and team announcements.


### PR DESCRIPTION
## Skill Information
- **Skill Name:** corpspeak
- **Category:** Writing & Research
- **Repository:** https://github.com/giorgiozamboni/corpspeak
- **I am the author:** [x] Yes [ ] No

## Quality Checklist
- [x] Has working SKILL.md file
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements
- [x] Alphabetically sorted within category

## Additional Context
corpspeak rewrites any text into corporate / C-suite register at three intensity levels (light, medium, extreme) while removing the structural patterns typical of AI-generated writing (em dashes, forced rule-of-three, significance inflation). It is bilingual EN/IT, with specific tuning for Italian office "itanglese". The repo includes SKILL.md with YAML frontmatter, IT/EN lexicons, an anti-AI gate, MIT license, and a packaged .skill in Releases.
