### PR TITLE
Add okf to Documentation & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 📚 Documentation & Automation
 
+#### okf
+**Source:** [mattjoyce/okf-skill](https://github.com/mattjoyce/okf-skill) | **Verified:** ⏳
+**Description:** Authors and validates Open Knowledge Format (OKF) bundles — vendor-neutral knowledge as markdown files with YAML frontmatter.
+**Use Case:** Building a knowledge bundle/catalog as markdown, authoring concept docs, checking OKF conformance
+**Stars:** ⭐⭐⭐
+
 #### documentation-generator
 **Status:** Community-needed
 **Description:** Auto-generate API documentation and keep docs synchronized with code.


### PR DESCRIPTION
Adds the **okf** skill to the 📚 Documentation & Automation category.

- **Source:** https://github.com/mattjoyce/okf-skill
- **What it does:** Authors and validates Open Knowledge Format (OKF) bundles — vendor-neutral knowledge represented as a directory of markdown files with YAML frontmatter (no schema registry, no SDK required).
- **Use case:** Building a knowledge bundle/catalog as markdown, authoring concept documents, and checking OKF conformance.

Meets the quality criteria: working `SKILL.md` with valid YAML frontmatter, README with install/usage, actively maintained, open source (Apache-2.0), no malicious code. Installable via the mattjoyce/claude-plugins marketplace.