### PR TITLE
Add NotFair to Skill Collections (SEO, Google Ads & Meta Ads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) | 20+ | @nowork-studio | SEO, GEO, Google Ads & Meta Ads via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP |
 
 ---
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a genuinely useful resource for the Claude community.

I'd like to add **NotFair** ([nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)), an open-source collection of 20+ Claude Code skills focused on SEO and paid advertising work. It currently has ~2.9k stars on GitHub.

The skills cover:
- **SEO** — site analysis, keyword research, meta tags, schema markup, GEO optimization, content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — ROAS analysis, creative fatigue, audience overlap (Facebook + Instagram)

What makes it distinct is that it connects to live data through the **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP**, so the skills work with real account data rather than just providing generic advice.

I've added it to the Skill Collections table as it's a multi-skill repo rather than a single skill. Happy to move it to a different section, adjust the description, or trim anything — just say the word.

## Skill Information
- **Skill Name:** NotFair
- **Category:** Skill Collections
- **Repository:** https://github.com/nowork-studio/NotFair
- **I am the author:** [ ] Yes [x] No

## Quality Checklist
- [x] Has working SKILL.md file
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements