### PR TITLE
Add ax-extract-workflow to Collaboration & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 🤝 Collaboration & Workflow
 
+#### ax-extract-workflow
+
+**Source:** [Necmttn/ax](https://github.com/Necmttn/ax) | **Verified:** ⏳
+**Description:** Reconstructs shipped-feature workflows from local ax session history.
+**Use Case:** Replaying the decisions and handoffs behind a finished feature
+**Stars:** ⭐⭐⭐
+
 #### requesting-code-review
 **Source:** [obra/superpowers](https://github.com/obra/superpowers) | **Verified:** ✅
 **Description:** Pre-review preparation and PR best practices with formatted diffs.


### PR DESCRIPTION
## Summary
Add ax-extract-workflow to the Collaboration & Workflow section.

## Why
This skill reconstructs the workflow behind a shipped feature from local ax session history, including decisions and handoffs.

## Checks
- git diff --check
- focused markdownlint check for the inserted README lines
- verified https://github.com/Necmttn/ax
- verified https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow

---

_Generated with [ax](https://github.com/Necmttn/ax)._

