### PR TITLE
Add todo.txt-skill to Collaboration & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large refactors, multi-step implementations
 **Stars:** ⭐⭐⭐⭐
 
+#### todo.txt-skill
+**Source:** [aguilera-ee/todo.txt-skill](https://github.com/aguilera-ee/todo.txt-skill)
+**Description:** Manage a todo.txt task list conversationally by driving the official todo.sh CLI.
+**Use Case:** Keeping a durable plain text task list your agent can use across conversations
+**Stars:** ⭐⭐⭐
+
 ---
 
 ### ⚙️ Development & Architecture


### PR DESCRIPTION
Adds todo.txt-skill under Collaboration & Workflow.

It manages a todo.txt task list by driving the official todo.sh CLI, giving an agent a durable plain text task list it can use across conversations.

Repository: https://github.com/aguilera-ee/todo.txt-skill
I am the author: yes