### PR TITLE
Add Forward Deployed Selling — new 💼 Business & Sales category

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   - [🎬 Media & Content Creation](#-media--content-creation)
   - [📊 Data & Analysis](#-data--analysis)
   - [✍️ Writing & Research](#️-writing--research)
+  - [💼 Business & Sales](#-business--sales)
   - [🎯 Meta Skills](#-meta-skills)
 - [Skill Collections](#skill-collections)
 - [FAQ](#faq)
@@ -424,6 +425,16 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Status:** Community-needed
 **Description:** Create clear technical documentation following industry best practices.
 **Use Case:** API docs, user manuals, technical specifications
+
+---
+
+### 💼 Business & Sales
+
+#### forward-deployed-selling
+**Source:** [vonarmen-wq/forward-deployed-selling](https://github.com/vonarmen-wq/forward-deployed-selling) | **Verified:** ✅
+**Description:** Enterprise AI sales methodology skill. Teaches discovery-led selling, economic buyer navigation, and deal architecture for complex multi-stakeholder AI initiatives.
+**Use Case:** Enterprise account strategy, AI deal coaching, objection handling, pipeline qualification
+**Stars:** ⭐⭐⭐⭐
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a new **💼 Business & Sales** skill category (the first of its kind in this list) and includes [forward-deployed-selling](https://github.com/vonarmen-wq/forward-deployed-selling) as the inaugural entry.

## The Skill

**forward-deployed-selling** teaches enterprise AI sales methodology through Claude:
- Discovery-led selling for complex AI deals
- Economic buyer navigation (CFO/CTO/board-level)  
- Multi-stakeholder deal architecture
- Objection handling specific to enterprise AI initiatives
- Pipeline qualification using the FDRI framework

## Why a new category?

The current skill categories cover development, testing, debugging, docs, and media — but nothing for go-to-market or business workflows. Enterprise sellers and revenue teams are a growing Claude user segment, and this creates a natural home for sales/GTM skills.

## Links
- GitHub: https://github.com/vonarmen-wq/forward-deployed-selling
- 65+ stars, Apache 2.0, active maintenance
- Skill format: standard AgentSkill SKILL.md