### PR TITLE
Add trace-my-code (Development & Architecture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### ⚙️ Development & Architecture
 
+#### trace-my-code
+**Source:** [kgohil/trace-my-code](https://github.com/kgohil/trace-my-code) | **Verified:** ✅
+**Description:** Keeps a living trace of your codebase (domain language, architecture, reuse patterns), current via a drift hook, so the agent reads it and reuses what already exists instead of rebuilding it.
+**Use Case:** Feature development, safe refactors, onboarding — read the map, follow the pattern, fix shared code once
+**Stars:** ⭐⭐⭐
+
 #### mcp-builder
 **Source:** [anthropics/skills](https://github.com/anthropics/skills) | **Verified:** ✅
 **Description:** Create high-quality Model Context Protocol servers for external integrations.


### PR DESCRIPTION
Adds **trace-my-code** under Development & Architecture.

- **Source:** https://github.com/kgohil/trace-my-code (public, MIT, valid `SKILL.md`)
- Keeps a living trace of the codebase — domain language, architecture, reuse patterns — current via a drift hook, so a coding agent reads it and reuses what already exists instead of rebuilding it. Reuse-first on by default; installs as a skill or Claude Code / Codex plugin.
- Matches the section's entry block format. Link is live (passes validate-links).