### PR TITLE
Add longbridge-warrant-hunter to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 📊 Data & Analysis
 
+#### [longbridge-warrant-hunter](https://github.com/naisi-alibaba/longbridge-warrant-hunter)
+**Source:** Community | **Verified:** ⏳
+**Description:** Hong Kong warrant (窝轮) & CBBC risk-reward analysis, long and short, on the Longbridge OpenAPI MCP via a "fish-positioning" workflow.
+**Use Case:** HK warrant/option selection, entry timing, stop & target planning (research only, not investment advice)
+
 #### data-visualization
 **Status:** Community-needed
 **Description:** Create charts, graphs, and interactive visualizations from datasets.


### PR DESCRIPTION
Adds a real, **linked** open-source community skill to the **Data & Analysis** category (most current entries there are unlinked / community-needed placeholders).

**longbridge-warrant-hunter** — Hong Kong warrant (窝轮) & CBBC (牛熊证) risk-reward analysis, long & short, built entirely on the **Longbridge OpenAPI MCP**, using a "fish-positioning" workflow (head / mid / tail, symmetric for calls & puts). MIT, bilingual (中文 / EN) docs, ships a paper-trading worked example.

Repo: https://github.com/naisi-alibaba/longbridge-warrant-hunter

⚠️ Research / analysis tool, **not investment advice**.
