### PR TITLE
Add enterprise-architect skill (Development & Architecture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Code smell detection and systematic refactoring techniques.
 **Use Case:** Legacy code modernization, improving code quality
 
+#### enterprise-architect
+**Source:** [rafalr100/enterprise-architect-skill](https://github.com/rafalr100/enterprise-architect-skill) | **Verified:** ⏳ (pending maintainer review)
+**Description:** Makes Claude operate as a world-class, organisation-agnostic Enterprise Architect — discovery-first, capability-first, with named trade-offs and one clear recommendation. TOGAF, Zachman, C4, Wardley, and DDD applied as silent lenses.
+**Use Case:** Target/reference architectures, ADRs, capability maps, technology strategy & roadmaps, trade-off analysis, audience-tiered architecture decks (board / solution-architect / engineering)
+
 ---
 
 ### 🔒 Security & Performance


### PR DESCRIPTION
Adds the **enterprise-architect** skill to the ⚙️ Development & Architecture section.

- **Repo:** https://github.com/rafalr100/enterprise-architect-skill
- **License:** MIT
- **What it is:** an organisation-agnostic Claude Skill that makes Claude operate as a world-class Enterprise Architect — discovery-first (asks the questions that change the answer before designing), capability-first, always surfaces the trade-off, and commits to one recommendation. TOGAF/Zachman/C4/Wardley/DDD are used as silent lenses, not recited.
- Produces real EA artifacts (ADRs, reference/target architectures, capability maps, options analyses) and audience-tiered decks (board / solution-architect / engineering).

Checklist:
- ✅ Working `SKILL.md` with YAML frontmatter (`name`, `description`)
- ✅ Clear documentation and use cases (README + on-demand reference files)
- ✅ Actively maintained (just published)
- ✅ Relevant to Claude workflows
- ✅ No security-sensitive or malicious code (documentation-only skill)

I set **Verified: ⏳ (pending maintainer review)** rather than self-marking ✅ — happy for you to verify and adjust.