### PR TITLE
Add bria-ai to Media & Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 🎬 Media & Content Creation
 
+#### bria-ai
+**Source:** [Bria-AI/bria-skill](https://github.com/Bria-AI/bria-skill/tree/main/skills/bria-ai) | **Verified:** ⏳
+**Description:** Generate, edit, and remove image backgrounds via the Bria.ai API — text-to-image, natural-language edits, transparent PNGs.
+**Use Case:** Hero images, product photos, icons, and cutouts for web, e-commerce, and marketing pipelines
+**Stars:** ⭐⭐⭐⭐
+
 #### canvas-design
 **Source:** Community | **Verified:** ⏳
 **Description:** Create visual designs and graphics using Claude's canvas capabilities.


### PR DESCRIPTION
## Skill Information
- **Skill Name:** bria-ai
- **Category:** 🎬 Media & Content Creation
- **Repository:** [Bria-AI/bria-skill](https://github.com/Bria-AI/bria-skill/tree/main/skills/bria-ai)
- **I am the author:** [x] Yes [ ] No

## Quality Checklist
- [x] Has working SKILL.md file
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements
- [x] Alphabetically sorted within category

## Additional Context
`bria-ai` is the flagship skill in the [Bria-AI/bria-skill](https://github.com/Bria-AI/bria-skill) collection (61★): commercially-safe, royalty-free AI image generation, editing, and background removal across 20+ API endpoints. The repo also ships companion skills (`remove-background`, `video-remove-background`, `vgl`, `image-utils`); per the one-skill-per-PR guideline I am submitting the flagship here and can open separate PRs for the others if useful.

Opened as a **draft** for review.