### PR TITLE
Add multi-stack-mcp — UI sections across Next.js, Flutter, WordPress, Vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Code smell detection and systematic refactoring techniques.
 **Use Case:** Legacy code modernization, improving code quality
 
+#### multi-stack-mcp
+**Source:** [VovikP/multi-stack-mcp](https://github.com/VovikP/multi-stack-mcp) | **Verified:** Community
+**Description:** Generates native UI sections (hero, pricing, features, CTA) for Next.js, Flutter, WordPress, and Vue from a unified pattern catalog with shared design tokens. Ships a token + slot denylist and atomic safe-write.
+**Use Case:** Multi-stack landing pages, brand-consistent UI across Next.js/Flutter/WordPress/Vue with one tokens.json
+**Stars:** Community submission
+
 ---
 
 ### 🔒 Security & Performance


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **multi-stack-mcp** — a Claude Code skill that generates native UI sections for **Next.js, Flutter, WordPress, and Vue** from a unified pattern catalog with shared design tokens.

**Repo:** https://github.com/VovikP/multi-stack-mcp (MIT)
**Tag:** v0.1.3-alpha
**Differentiator:** Every other UI-section skill is locked to one stack. This one ships 4 hand-written stack realizations per pattern (hero / pricing / features / CTA so far), all driven by a single `tokens.json`. It also ships a real security model — token + slot denylist, atomic safe-write with O_EXCL, symlink-refusing walkers, base64-shaped-string detection — which none of shadcn / 21st.dev / BYQ ship.

**Audited:** four independent macro-rounds with 18 total agent passes. SECURITY.md threat model (T1-T7) all enforced; CI exercises 4×4 cross-product + adversarial smoke tests on every PR.

Happy to revise the wording or move to a different category — just let me know what works.
