### PR TITLE
add remote openclaw to community resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Skills can execute code, so only install from trusted sources. Review the skill'
 ### Community Resources
 - [Claude Skills Hub](https://claudeskills.info/) - Searchable skills directory
 - [Simon Willison's Blog](https://simonwillison.net/2025/Oct/16/claude-skills/) - "Claude Skills are awesome, maybe a bigger deal than MCP"
+- [Remote OpenClaw](https://www.remoteopenclaw.com/skills) - searchable directory of skills and mcp servers for Claude Code, OpenClaw, Hermes and Codex
 
 ### Tools & Utilities
 - [create-claude-skill](https://github.com/anthropics/skills) - Interactive skill creator


### PR DESCRIPTION
thanks for the list, the way you split related lists vs community resources is really clean. added remote openclaw under community resources right by the claude skills hub entry since it's a similar searchable directory, just covering openclaw, hermes and codex on top of claude code. happy to move it if you'd prefer.