### PR TITLE
Add Mamba Labs GTM Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [mambalabsdev/mamba-labs-skills](https://github.com/mambalabsdev/mamba-labs-skills) | 4 | @mambalabsdev | Signal-based GTM outbound: ICP definition, cold email audits, domain health, hiring signals |
 
 ---
 


### PR DESCRIPTION
Adding [Mamba Labs GTM Skills](https://github.com/mambalabsdev/mamba-labs-skills), a collection of 4 free, MIT-licensed GTM skills for signal-based outbound workflows.

Skills included:
- **ICP Definition Builder**: Guided interview that outputs a structured ICP block for Clay, CRM filters, or targeting briefs.
- **Cold Email Structure Checker**: Audits cold email drafts against a 7-point framework with pass/fail scorecard and revised version.
- **Domain Health Pre-Check**: Scans SPF, DKIM, DMARC, and blacklist status via the Mamba Labs Domain Deliverability Checker MCP server.
- **Hiring Signal Spotter**: Detects GTM hiring signals on Greenhouse, Lever, and Ashby via the Mamba Labs GTM Hiring Signal Scraper MCP server.

Compatible with Claude Code, Codex CLI, Cursor, Gemini CLI, and MCP-compatible agents. Each skill includes YAML frontmatter with name, description, license, metadata (category + tags), compatibility, and version fields. The repo ships with a `.claude-plugin/marketplace.json` manifest.
