### PR TITLE
docs: maintainer line with site + blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,4 +618,6 @@ Special thanks to:
 
 **Follow** this repo for updates | **Star** to support | **Contribute** to grow the ecosystem
 
+Maintained by [Karan Bansal](https://karanbansal.in) · [Blog: Claude Code, MCP, production agentic AI](https://karanbansal.in/blog/)
+
 </div>


### PR DESCRIPTION
Adds a maintainer line to the footer linking karanbansal.in and the blog.