### PR TITLE
Add skill: build-cms (thabxi/cms-skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Interactive demos, prototypes, data visualizations
 **Stars:** ⭐⭐⭐⭐
 
+#### build-cms
+**Source:** [thabxi/cms-skills](https://github.com/thabxi/cms-skills)
+**Description:** Retrofit a secure, SEO-ready, Webflow-like CMS onto any vibe-coded app — maps every hardcoded front-end field to an editable admin panel.
+**Use Case:** Making vibe-coded apps production-ready — editable content, SEO (sitemap, meta, JSON-LD, redirects), secure admin
+
 #### api-development
 **Status:** Community-needed
 **Description:** RESTful API design patterns with OpenAPI/Swagger generation.


### PR DESCRIPTION
## What

Adds **build-cms** to Development & Architecture.

**Repo:** https://github.com/thabxi/cms-skills (MIT, tagged v1.0.0)

A fire-and-forget skill that retrofits a Webflow-like CMS onto vibe-coded / front-end-first apps. Invoked as `/build-cms`, it analyzes the codebase (framework, database, rendering, routes), runs one batched interview, proposes architecture options for where the CMS should live, then builds end to end: a `FIELD-MAP.md` contract mapping every hardcoded front-end field to an editable CMS field, a Webflow-like admin (Content/SEO tabs, SERP preview, media library, draft/publish), full SEO (auto-regenerating sitemap, meta/OG, JSON-LD, canonical URLs, automatic 301s on slug changes), and security by construction (server-side authz, validated inputs, sanitized rich text, magic-byte upload checks, plus active security probes before handoff).

## Checklist

- ✅ Working `SKILL.md` with YAML frontmatter (`skills/build-cms/SKILL.md`)
- ✅ Clear documentation and use cases (README + 6 reference docs)
- ✅ Actively maintained (created and updated July 2026)
- ✅ Relevant to Claude workflows (installable via `npx skills add thabxi/cms-skills` or as a Claude Code plugin marketplace)
- ✅ No security vulnerabilities or malicious code — documentation-only skill, no executable scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)