### PR TITLE
Add aigent-OS to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [wrg32786/aigent-os](https://github.com/wrg32786/aigent-os) | 65+ | @wrg32786 | Full Claude Code OS — persistent vault memory, /open + /close session rhythm, subagents, hooks & daemons |
 
 ---
 


### PR DESCRIPTION
Adds wrg32786/aigent-os to the Skill Collections table — a full Claude Code OS (persistent vault memory, /open+/close session rhythm, subagents, hooks & daemons).
Skill count (65+) verified via GitHub API against the repo's skills/ directory.