### PR TITLE
Add stop-ai-slop to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** HR communications, team updates, policy announcements
 **Stars:** ⭐⭐⭐
 
+#### stop-ai-slop
+**Source:** [Lekha-Reddy-git-hub/stop-ai-slop](https://github.com/Lekha-Reddy-git-hub/stop-ai-slop) | **Verified:** ⏳
+**Description:** Strips AI tells from writing without flattening it into beige, tuned per channel (X, LinkedIn, cold and warm email). Self-improving via an excess-vocabulary miner that finds new tells as models change.
+**Use Case:** Cleaning AI-drafted posts, emails, and articles so they read human
+**Stars:** ⭐⭐⭐
+
 #### research-assistant
 **Status:** Community-needed
 **Description:** Gather, synthesize, and cite sources for research projects.


### PR DESCRIPTION
Adds **stop-ai-slop** to the Writing & Research category.

**Skill Name:** stop-ai-slop
**Category:** Writing & Research
**Repository URL:** https://github.com/Lekha-Reddy-git-hub/stop-ai-slop
**I am the author:** Yes

**What it does:** Removes AI tells from writing (X posts, LinkedIn posts, cold and warm emails, articles) without flattening it into a generic beige voice. Tiered rules instead of blanket bans, per-channel guidance, an objective slop score (slop_score.py), and a self-improving miner (slop_miner.py) that surfaces new tells as models change. Includes a valid SKILL.md with YAML frontmatter. MIT licensed, based on stop-slop by Hardik Pandya.