### PR TITLE
Add deep-security-check (defensive security assessment skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 🔒 Security & Performance
 
+#### [deep-security-check](https://github.com/give-jd/deep-security-check)
+**Status:** Available
+**Description:** Defensive read-only security assessment: Semgrep SAST, osv-scanner dependency CVEs, and gitleaks secrets detection with a reproducible 0-100 (A-F) grade.
+**Use Case:** Security audits, pre-release checks, due-diligence on codebases you own
+
 #### security-review
 **Status:** Community-needed
 **Description:** Automated vulnerability scanning and OWASP compliance checks.


### PR DESCRIPTION
Adds [deep-security-check](https://github.com/give-jd/deep-security-check) — a defensive, read-only security assessment skill for Claude Code. It runs Semgrep (SAST), osv-scanner (dependency CVEs) and gitleaks (secrets) against a local project and produces a report with a reproducible reliability grade (0-100, A-F) computed by a deterministic rubric, not model opinion.

- MIT licensed, static analysis only, never sends traffic to live targets
- Works standalone without Claude too
- v0.1.0 released: https://github.com/give-jd/deep-security-check/releases/tag/v0.1.0

Entry follows the existing format of the section. Thanks for maintaining the list!