### PR TITLE
Add seo-translator (SEO-aware translation skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ---
 
+#### seo-translator
+**Source:** [Skillproofdev/seo-translator](https://github.com/Skillproofdev/seo-translator) | **Verified:** ⏳
+**Description:** SEO-aware translation for localizing sites and content — per-market registers, protected product names and code, anti-AI-pattern pass; measured 10-language benchmark in the README.
+**Use Case:** Multilingual SEO, site localization, hreflang content preparation
+
 ### 🎯 Meta Skills
 
 #### skill-creator


### PR DESCRIPTION
Adds [seo-translator](https://github.com/Skillproofdev/seo-translator) to Writing & Research, following the entry format (left Verified as ⏳ and omitted the Stars rating for the maintainer to assign).

SEO-aware translation for localizing sites and content: classifies SEO fields vs marketing vs UI strings, per-market registers, protects product names and code, anti-AI-pattern pass. The README carries a measured 10-language benchmark (tokens + wall time per language) from localizing a 4,500-page site.

Disclosure: we're the authors (SkillProof — the tested Claude skills directory).