### PR TITLE
Add ditto to Development & Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Interactive demos, prototypes, data visualizations
 **Stars:** ⭐⭐⭐⭐
 
+#### ditto
+**Source:** [ohad6k/ditto](https://github.com/ohad6k/ditto) | **Verified:** ⏳
+**Description:** Mines your local Claude Code/Codex/OpenCode session logs into a personal profile your agent loads before every task.
+**Use Case:** Starting every session with your working preferences and conventions instead of a cold start
+**Stars:** ⭐⭐⭐⭐
+
 #### api-development
 **Status:** Community-needed
 **Description:** RESTful API design patterns with OpenAPI/Swagger generation.


### PR DESCRIPTION
## Skill Information
- **Skill Name:** ditto
- **Category:** Development & Architecture
- **Repository:** https://github.com/ohad6k/ditto
- **I am the author:** [x] Yes [ ] No

## Quality Checklist
- [x] Has working SKILL.md file
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements
- [x] Alphabetically sorted within category

## Additional Context
ditto is an MIT-licensed, single-file, stdlib-only Python tool that mines local AI coding session logs (Claude Code, Codex, Copilot CLI, OpenCode) into a personal working profile (you.md) the agent loads before every task. Runs entirely locally; installs as a Claude Code skill via 'npx skills add ohad6k/ditto'.