### PR TITLE
Add Apify LinkedIn Posts skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,17 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 📊 Data & Analysis
 
+#### apify-linkedin-posts-scraper
+**Source:** [johnisanerd/claude-skill-linkedin-posts-scraper](https://github.com/johnisanerd/claude-skill-linkedin-posts-scraper) | **Verified:** ⏳
+**Description:** Scrape public LinkedIn posts into structured JSON via the Apify LinkedIn Posts API.
+**Use Case:** Content research, competitor monitoring, building a LinkedIn posts dataset
+
+#### apify-linkedin-post-engagement
+**Source:** [johnisanerd/claude-skill-linkedin-post-engagement](https://github.com/johnisanerd/claude-skill-linkedin-post-engagement) | **Verified:** ⏳
+**Description:** Analyze LinkedIn post engagement (reactions, comments, shares) via the Apify LinkedIn Posts API.
+**Use Case:** Rank top-performing posts, benchmark competitors, engagement reporting
+
+
 #### data-visualization
 **Status:** Community-needed
 **Description:** Create charts, graphs, and interactive visualizations from datasets.


### PR DESCRIPTION
Two agent skills for the Apify LinkedIn Posts API: apify-linkedin-posts-scraper (scrape posts to JSON) and apify-linkedin-post-engagement (analyze engagement). Both follow the agentskills.io standard and link to public repos with working SKILL.md files.