### PR TITLE
Add two YouTube transcript skills (Apify-powered)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,17 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 📊 Data & Analysis
 
+#### apify-youtube-transcript-api
+**Source:** [johnisanerd/claude-skill-youtube-transcript-api](https://github.com/johnisanerd/claude-skill-youtube-transcript-api) | **Verified:** ⏳
+**Description:** Fetch YouTube transcripts as structured JSON, SRT, or VTT via a hosted YouTube transcript API on Apify.
+**Use Case:** Video summarization, subtitle export, transcript datasets
+
+#### apify-youtube-transcripts-llm-training-data
+**Source:** [johnisanerd/claude-skill-youtube-transcripts-llm-training-data](https://github.com/johnisanerd/claude-skill-youtube-transcripts-llm-training-data) | **Verified:** ⏳
+**Description:** Build LLM training data from YouTube transcripts in bulk, with provenance metadata per video.
+**Use Case:** Fine-tuning corpora, RAG document collections, dataset cards
+
+
 #### data-visualization
 **Status:** Community-needed
 **Description:** Create charts, graphs, and interactive visualizations from datasets.


### PR DESCRIPTION
Adds apify-youtube-transcript-api (transcripts as JSON, SRT, or VTT) and apify-youtube-transcripts-llm-training-data (bulk transcript corpora with provenance metadata) to Data & Analysis, matching the existing entry format. Both live in per-skill repos with the agentskills.io layout and install via npx skills add.