### PR TITLE
Add first-principles-destructor to Meta Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large-scale refactoring, parallel development streams
 **Stars:** ⭐⭐⭐⭐⭐
 
+#### first-principles-destructor
+**Source:** [reshadat/first-principles-destructor](https://github.com/reshadat/first-principles-destructor) | **Verified:** ✅
+**Description:** Strips a problem to its reality floor, prices the convention tax, and rebuilds from first principles. Works with Claude Code, Codex CLI, Gemini CLI, Cursor, and Kiro.
+**Use Case:** Challenging inherited assumptions, architecture decisions, cost and complexity audits
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ## Skill Collections


### PR DESCRIPTION
Adds [first-principles-destructor](https://github.com/reshadat/first-principles-destructor) (24 stars): a universal agent skill that strips assumptions to the reality floor, calculates the convention tax, and rebuilds from first principles. Working SKILL.md with YAML frontmatter, actively maintained, works across Claude Code, Codex CLI, Gemini CLI, Cursor, and Kiro.

Set Verified per your own process — happy to adjust the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)