### PR TITLE
Add skill-receipts to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [sjh9714/skill-receipts](https://github.com/sjh9714/skill-receipts) | 2 (admitted) | @sjh9714 | Benchmark-gated skills: each must beat baseline AND a placebo on hidden hold-out tests; rejects published |
 
 ---
 


### PR DESCRIPTION
Adds [skill-receipts](https://github.com/sjh9714/skill-receipts) to the Skill Collections table — a collection where every skill must beat both a no-instruction baseline and a placebo prompt on hidden hold-out acceptance tests before it's admitted (pre-registered rule, first commit). Skills that fail are published with full tables.

What makes it different from existing collections:
- 436 benchmark runs committed as raw logs + per-run patches; README tables regenerate from them byte-identically in CI
- A placebo control arm (style-only prompt) — it made code BIGGER on 8 of 12 tasks, which is why on/off comparisons alone overstate skill effects
- Includes pre-registered audits of popular rulesets (ponytail 87k★, caveman 92k★) under the same accuracy-gated harness
- 2 admitted skills (underkill, repro-first), 2 published rejects

Installable via the Claude Code plugin marketplace or per-skill SKILL.md files.