### PR TITLE
Add keyword-icons skill (Media & Content Creation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Creative coding, data visualization, generative design
 **Stars:** ⭐⭐⭐
 
+#### keyword-icons
+**Source:** [Community](https://github.com/ruthless-coder-ai/keyword-icons) | **Verified:** ⏳
+**Description:** Generate presentation-ready PNG icons from a keyword — three distinct concepts, 1:1 transparent line icons, recolorable via lossless SVG re-render.
+**Use Case:** PowerPoint/Keynote decks, slide iconography, brand-colored icon sets
+
 #### video-editing-helper
 **Status:** Community-needed
 **Description:** Assist with video editing workflows, ffmpeg commands, and transitions.


### PR DESCRIPTION
Adds [keyword-icons](https://github.com/ruthless-coder-ai/keyword-icons) under Media & Content Creation.

It turns a keyword into three presentation-ready icon concepts (e.g. "hospital" → building+cross / cross badge / first-aid kit): 1:1 transparent PNGs in a consistent line style. SVG sources use currentColor, so recoloring to brand colors is a lossless re-render. Works in any language, MIT licensed, runs fully locally (Python + Playwright), no external APIs. Example outputs in the repo README.