### PR TITLE
Add signs-of-ai — bilingual (EN/ES) AI-writing de-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** HR communications, team updates, policy announcements
 **Stars:** ⭐⭐⭐
 
+#### signs-of-ai
+**Source:** [peopleworks/SignsofAI](https://github.com/peopleworks/SignsofAI) | **Verified:** ⏳
+**Description:** De-slop AI writing in English & Spanish — rewrite a draft to remove AI tells, or judge whether text reads as AI-written.
+**Use Case:** Editing AI-generated prose and academic/writing integrity; the front end of a scored engine (web app, CLI, and MCP server)
+**Stars:** ⭐⭐⭐
+
 #### research-assistant
 **Status:** Community-needed
 **Description:** Gather, synthesize, and cite sources for research projects.


### PR DESCRIPTION
Adds **signs-of-ai** to the ✍️ Writing & Research section.

A drop-in skill that removes the tells of AI-generated writing — or judges whether text reads as AI-written — in **English and Spanish** (the Spanish rule-pack is derived from scratch, not translated). It's the human-judgment front end of a real, open-source (MIT), privacy-first writing-integrity engine, so it can hand off to a scored analyzer via web app, CLI, or MCP server.

- Skill: `skill/signs-of-ai/SKILL.md` (YAML frontmatter, two modes: edit + detect) plus an `eval.md` self-check.
- Repo: https://github.com/peopleworks/SignsofAI — actively maintained.

Thanks for curating this list!
