### PR TITLE
Add ai-content-skills to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### ✍️ Writing & Research
 
+#### ai-content-skills
+**Source:** [MarchTalk/ai-content-skills](https://github.com/MarchTalk/ai-content-skills)
+**Description:** Quality-gated Chinese content-writing skills that force real research before drafting and veto AI-sounding output.
+**Use Case:** Blog/social copywriting, content quality review, catching generic AI-flavored drafts before publishing
+**Stars:** ⭐⭐⭐
+
 #### brand-guidelines
 **Source:** Community | **Verified:** ⏳
 **Description:** Maintain and enforce brand voice, style, and messaging consistency.


### PR DESCRIPTION
## Skill Information
- **Skill Name:** ai-content-skills
- **Category:** ✍️ Writing & Research
- **Repository:** https://github.com/MarchTalk/ai-content-skills
- **I am the author:** [x] Yes

## Quality Checklist
- [x] Has working SKILL.md file
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements
- [x] Alphabetically sorted within category

## Additional Context
11 skills for Chinese-language content writing (blog/social copy), built around two enforced gates rather than loose suggestions: material-research blocks writing until real, verifiable facts are gathered for fact-heavy content, and quality-gate does a final check with an explicit AI-tone veto (catches mechanical parallelism, templated openers, generic filler) plus per-content-type checklists so opinion/persona pieces aren't graded like sales copy. MIT licensed, README has an English summary section.