### PR TITLE
Add collage-design to Media & Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Creative coding, data visualization, generative design
 **Stars:** ⭐⭐⭐
 
+#### collage-design
+**Source:** [polgarp/collage-design](https://github.com/polgarp/collage-design)
+**Description:** Cuts and layers real open-licensed archive imagery into finished collage art as .svg and .png, with a full licence ledger
+**Use Case:** Posters, album and book covers, prints — publishable art built only from verifiably licensed source material
+**Stars:** ⭐⭐⭐⭐
+
 #### video-editing-helper
 **Status:** Community-needed
 **Description:** Assist with video editing workflows, ffmpeg commands, and transitions.


### PR DESCRIPTION
Adds [collage-design](https://github.com/polgarp/collage-design), a skill that makes cut-and-layer collage art from real, open-licensed archive imagery.

- Sources only open-licensed material and writes a full attribution ledger (URL, creator, licence) for every fragment
- Outputs a self-contained `.svg` plus `.png`, alongside the parametric build script that made the piece
- Apache-2.0; installable as a Claude Code plugin or a plain skill
- README shows four finished pieces with the one-line briefs that produced them

Requires ImageMagick/Inkscape/librsvg locally, so it is Claude Code only — flagged in the README.