### PR TITLE
Add absolutely-not to Collaboration & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large refactors, multi-step implementations
 **Stars:** ⭐⭐⭐⭐
 
+#### absolutely-not
+**Source:** [TahaZahit/absolutely-not](https://github.com/TahaZahit/absolutely-not)
+**Description:** Bans reflexive agreement and unverified completion claims, with a Stop hook that blocks "done" when files changed and nothing ran.
+**Use Case:** Sessions where the agent agrees before checking, or reports success without running anything
+**Stars:** ⭐⭐⭐
+
 ---
 
 ### ⚙️ Development & Architecture


### PR DESCRIPTION
## Skill Information
- **Skill Name:** absolutely-not
- **Category:** 🤝 Collaboration & Workflow
- **Repository:** https://github.com/TahaZahit/absolutely-not
- **I am the author:** [x] Yes [ ] No

## Quality Checklist
- [x] Has working SKILL.md file (valid YAML frontmatter)
- [x] Clear documentation (README with install, configuration, and eval results)
- [x] Claude relevance — ships as a Claude Code plugin; `claude plugin validate --strict` passes
- [x] Active maintenance — created and maintained this month
- [x] Open source (MIT)
- [x] No malicious code — the Stop hook is stdlib-only Python, reads the transcript, writes a JSON verdict to stdout, and spawns no subprocesses

## What it does

Two rules, plus enforcement. The skill bans reflexive agreement (verify a claim about code before confirming it) and completion claims that no command backs. A Stop hook then blocks the turn when all three hold: files were edited, no verification command ran, and the closing message claims success. It fires at most once per turn, and "I did not verify this" clears it — the goal is an honest summary, not forced testing.

`tests/test_stop_guard.py` covers the hook in both directions (14 tests, blocked cases and left-alone cases, plus malformed transcripts).

## Note on the two maintainer fields

I left **Verified** off the entry and set **Stars** to ⭐⭐⭐ rather than rating my own submission higher — both look like fields for you to set, so please adjust or strip them as you see fit.

## Honest caveat

The repo's own eval write-up reports that on current models (Fable, Opus, Sonnet) the unaided agent already passes 12 of 14 trap scenarios; the skill changed the outcome on 2, at one session per condition. That is recorded in `evals/README.md` along with what a real evaluation would still need. Happy to close this if that is below the bar for the list.