### PR TITLE
Add Marketing Skills (49 marketing skills for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [Marketing Skills](https://github.com/coreyhaines31/marketingskills) | 49 | @coreyhaines31 | Marketing: SEO, copywriting, cold email, pricing, CRO, ads, analytics |
 
 ---
 


### PR DESCRIPTION
Adding **Marketing Skills** — an open-source library of 49 marketing skills for AI agents (SEO, copywriting, cold email, pricing, CRO, ads, analytics).

- Repo: https://github.com/coreyhaines31/marketingskills (42k+ stars)
- Install: `npx skills add coreyhaines31/marketingskills`
- Guides & examples: https://marketing-skills.com

MIT licensed. Thanks for maintaining the list!