### PR TITLE
Add feynman-it to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Create clear technical documentation following industry best practices.
 **Use Case:** API docs, user manuals, technical specifications
 
+#### feynman-it
+**Source:** [TadTheFisherman/feynman-it](https://github.com/TadTheFisherman/feynman-it) | **Verified:** ⏳
+**Description:** Turns any topic into a hand-illustrated PDF using the Feynman technique -- plain language, an analogy diagram, and named misconceptions.
+**Use Case:** Understanding a confusing AI answer, a jargon-heavy article, an unfamiliar codebase, or compressing a book.
+**Stars:** ⭐⭐⭐
+
 ---
 
 ### 🎯 Meta Skills


### PR DESCRIPTION
## Skill Information

Skill Name: feynman-it
Category: Writing & Research
Repository URL: https://github.com/TadTheFisherman/feynman-it
I am the author of this skill: Yes

## Quality Checklist

Verified against the requirements: has a working SKILL.md with YAML frontmatter, clear documentation, active maintenance (commits today), relevant to Claude Code workflows, no security issues, follows the format in CONTRIBUTING.md, alphabetically sorted within the category, all links valid and working, description under 150 characters, and includes a specific use case.

## Skill Entry

Please paste your formatted skill entry here:

```markdown
#### feynman-it
**Source:** [TadTheFisherman/feynman-it](https://github.com/TadTheFisherman/feynman-it)
**Description:** Turns any topic into a hand-illustrated PDF using the Feynman technique -- plain language, an analogy diagram, and named misconceptions.
**Use Case:** Understanding a confusing AI answer, a jargon-heavy article, an unfamiliar codebase, or compressing a book.
**Stars:** ⭐⭐⭐
```

## Why This Skill is Valuable

Most "explain it simply" prompts just shorten the same wall of text. Feynman It instead enforces the actual Feynman method -- a jargon-free one-sentence opener, an analogy that earns its own diagram, an explicit misconceptions section, and a one-breath recap -- and holds itself to a "pictures-only test" where flipping through just the diagrams should tell the whole story. It's MIT licensed with nine example PDFs in the repo (each built with the skill itself) spanning AI/dev concepts, an unfamiliar codebase, a whole book, physics, economics, and math.

I placed it under Writing & Research since the skill's core loop is research-then-write (understand a topic, then explain it clearly) -- happy to move it if a maintainer prefers a different category.