### PR TITLE
Add Suede Creator Skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Looking for curated skill bundles? Start with these collections:
 |------------|--------|------------|------------|
 | [obra/superpowers](https://github.com/obra/superpowers) | 20+ | @obra | Development workflows & best practices |
 | [anthropics/skills](https://github.com/anthropics/skills) | 10+ | @anthropics | Official skills & document processing |
+| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 67 | @JasonColapietro | Code quality, design, marketing & shipping |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Suede Creator Skills to the Skill Collections table with its current 67-skill count, maintainer, and focus areas.

## Verification

- Confirmed the repository and all 67 skill folders are public.
- Confirmed the collection supports Claude Code and Codex.
- Confirmed the repository is MIT licensed and actively maintained.
- Ran git diff --check.