### PR TITLE
Add vox-director to Media & Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Creative coding, data visualization, generative design
 **Stars:** ⭐⭐⭐
 
+#### vox-director
+**Source:** [Alisa0808/vox-director](https://github.com/Alisa0808/vox-director) | **Verified:** ⏳
+**Description:** Turn a one-line topic into a finished paper-collage explainer video, generating script, keyframes, motion, voice-over, music and captions, then assembling them with ffmpeg.
+**Use Case:** Explainer videos, product ads, faceless short-form content
+**Stars:** ⭐⭐⭐⭐
+
 #### video-editing-helper
 **Status:** Community-needed
 **Description:** Assist with video editing workflows, ffmpeg commands, and transitions.


### PR DESCRIPTION
Adds one entry to **🎬 Media & Content Creation**, following the existing `#### skill-name` / Source / Description / Use Case / Stars format.

[Alisa0808/vox-director](https://github.com/Alisa0808/vox-director) is an MIT-licensed skill (SKILL.md, works in Claude Code and other agents) that turns a one-line topic into a finished paper-collage explainer video — script, keyframes, motion, voice-over, music and captions, assembled locally with ffmpeg. Sample output is embedded at the top of the README.

Rated ⭐⭐⭐⭐ per the Star Rating Guidelines; `Verified: ⏳` left for a maintainer to confirm. It sits next to the existing `video-editing-helper` Community-needed placeholder without overlapping it (generation vs. editing).