### PR TITLE
Add shopify-review-triage to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 
 ### 📊 Data & Analysis
 
+#### shopify-review-triage
+**Source:** [alfredtech2026/shopify-app-review-brief](https://github.com/alfredtech2026/shopify-app-review-brief/tree/main/docs/skills/shopify-review-triage) | **Verified:** ⏳
+**Description:** Turns public 1–3-star Shopify App Store reviews into a P0–P3 triage brief with source links and a needs-human-read bucket.
+**Use Case:** Weekly product or support triage of low-star reviews for one Shopify app or a portfolio
+**Stars:** ⭐
+
 #### data-visualization
 **Status:** Community-needed
 **Description:** Create charts, graphs, and interactive visualizations from datasets.


### PR DESCRIPTION
# Pull Request: Add Skill

## Skill Information

- **Skill Name:** shopify-review-triage
- **Category:** 📊 Data & Analysis
- **Repository URL:** https://github.com/alfredtech2026/shopify-app-review-brief/tree/main/docs/skills/shopify-review-triage
- **I am the author of this skill:** [x] Yes [ ] No

## Quality Checklist

Please verify that your submission meets these requirements:

- [x] Has working `SKILL.md` file with YAML frontmatter
- [x] Clear, concise documentation
- [x] Active maintenance (commits within last 6 months)
- [x] Relevant to Claude workflows (Code, Web, or API)
- [x] No security vulnerabilities or malicious code
- [x] Follows format requirements in CONTRIBUTING.md
- [x] Alphabetically sorted within category
- [x] All links are valid and working
- [x] Description is under 150 characters
- [x] Includes specific use case

## Skill Entry

```markdown
#### shopify-review-triage
**Source:** [alfredtech2026/shopify-app-review-brief](https://github.com/alfredtech2026/shopify-app-review-brief/tree/main/docs/skills/shopify-review-triage) | **Verified:** ⏳
**Description:** Turns public 1–3-star Shopify App Store reviews into a P0–P3 triage brief with source links and a needs-human-read bucket.
**Use Case:** Weekly product or support triage of low-star reviews for one Shopify app or a portfolio
**Stars:** ⭐
```

## Why This Skill is Valuable

Public app-store reviews are a feedback channel most small app teams read ad hoc, so a
one-star "checkout is broken" and a three-star "please add dark mode" get the same attention.
This skill applies one published rubric to rows of **public** review text and returns a
prioritized brief: P0 incident risk, P1 repeated friction, P2 pricing confusion,
P3 feature requests, plus an explicit **needs-human-read** bucket for rows the keyword pass
could not judge.

Three properties that make it more than a summarizer, and are enforced as hard rules in the
`SKILL.md`:

- **Every item stays traceable.** A row with no link is written `source: not captured` —
  never a guessed URL.
- **Nothing is dressed up as verified.** Everything the rubric alone produces is labeled
  *first pass — not human-checked*, and reviews are written as customer reports
  ("the reviewer reports the editor showed a blank screen"), not as confirmed defects.
- **It stays inside public data and never acts.** It refuses support tickets, merchant emails
  and order data, makes no coverage or outcome claims, and is draft-only — it never sends mail,
  posts a developer reply, or contacts a reviewer.

It needs no network access, no scripts and no system packages, so it is portable to any client
that supports the `SKILL.md` format.

## Testing

- [x] I have tested this skill with Claude (Code/Web/API)
- [x] The skill works as described
- [x] Installation instructions are clear

**What I actually ran (Claude Code 2.1.221, Opus, read-only, no network access and no
credentials):** I installed the skill into a scratch project's `.claude/skills/` directory and
invoked it on five clearly synthetic review rows (fictional apps, `example.invalid` URLs).

Result — it produced the expected brief and classified all five rows correctly:

| Row | Expected | Produced |
|---|---|---|
| "Checkout is completely broken… losing sales" | P0 incident risk | P0 incident risk |
| "Setup is confusing… too many steps" | P1 repeated friction | P1 repeated friction |
| "Kept getting charged after uninstalling" | P2 pricing confusion | P2 pricing confusion |
| "Would love a dark mode option" | P3 feature request | P3 feature request |
| Italian-language review | needs human read | needs human read |

It also honoured its own documented guardrails in that run: it flagged the single-row P1 as
"not yet a cluster", labeled the whole brief *first pass — not human-checked*, and declined to
translate-then-classify the non-English row. Nothing was sent or published.

## Additional Context

A few things stated plainly so you can judge them yourself:

- **I maintain the source repository.** This is a self-submission, disclosed above.
- **Claude Code assisted with this contribution** (policy research, the smoke test above, and
  this PR). I have reviewed and stand behind the entry.
- **Rating is deliberately conservative.** The skill was published 2026-08-02 and the repo has
  0 stars and no external adoption, so I rated it ⭐ per the CONTRIBUTING scale
  ("experimental, early stage") rather than the ⭐⭐⭐ default, and marked **Verified:** ⏳
  rather than ✅ since no one but me has reviewed it. I am not claiming community adoption.
- **Placement.** I put it at the top of 📊 Data & Analysis because every category in the README
  currently lists `**Source:**`-backed entries above `**Status:** Community-needed`
  placeholders, and this is that category's first sourced entry. Happy to move it if you would
  rather it sit elsewhere or be sorted differently.
- **Scope of the change.** One entry, `README.md` only, 6 added lines, no other edits. I did not
  touch the skills-count badge, since `update-badge.yml` regenerates that on push to `main`.
- **Links carry no tracking parameters** and point at the canonical skill directory in the
  source repo rather than a copy or a redirect.

The full file is here if you want to read it before deciding:
https://github.com/alfredtech2026/shopify-app-review-brief/blob/main/docs/skills/shopify-review-triage/SKILL.md

---

**By submitting this PR, I confirm that:**
- This contribution is my own work or I have the right to submit it
- I've read and followed the CONTRIBUTING.md guidelines
- I understand this project uses the MIT License (the skill itself is MIT)
