### PR TITLE
Add pr-review to Collaboration & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Large refactors, multi-step implementations
 **Stars:** ⭐⭐⭐⭐
 
+#### pr-review
+**Source:** [priyank766/OpenSource-SKILL](https://github.com/priyank766/OpenSource-SKILL) | **Verified:** ⏳
+**Description:** Detection-first pull request review; a weighted 10-point filter keeps only the 2-3 findings worth a comment.
+**Use Case:** Reviewing open-source PRs as a maintainer without burying the author in nits
+**Stars:** ⭐⭐⭐
+
 ---
 
 ### ⚙️ Development & Architecture


### PR DESCRIPTION
## Skill Information

- **Skill Name:** pr-review
- **Category:** 🤝 Collaboration & Workflow
- **Repository URL:** https://github.com/priyank766/OpenSource-SKILL
- **I am the author of this skill:** [x] Yes [ ] No

## Quality Checklist

- [x] Has working `SKILL.md` file with YAML frontmatter
- [x] Clear, concise documentation
- [x] Active maintenance (commits within last 6 months)
- [x] Relevant to Claude workflows (Code, Web, or API)
- [x] No security vulnerabilities or malicious code
- [x] Follows format requirements in CONTRIBUTING.md
- [ ] Alphabetically sorted within category — see note below
- [x] All links are valid and working
- [x] Description is under 150 characters (108)
- [x] Includes specific use case

**Note on sorting:** `### 🤝 Collaboration & Workflow` is not currently in
alphabetical order (it runs requesting-code-review → receiving-code-review →
using-git-worktrees → … → executing-plans), so I appended to the end of the section
to match existing file order rather than introduce an inconsistency. Happy to move
the entry wherever you prefer.

## Skill Entry

```markdown
#### pr-review
**Source:** [priyank766/OpenSource-SKILL](https://github.com/priyank766/OpenSource-SKILL) | **Verified:** ⏳
**Description:** Detection-first pull request review; a weighted 10-point filter keeps only the 2-3 findings worth a comment.
**Use Case:** Reviewing open-source PRs as a maintainer without burying the author in nits
**Stars:** ⭐⭐⭐
```

## Why This Skill is Valuable

Maintainers review pull requests they did not ask for, in time they do not have. A
general-purpose agent makes that worse by volume — a dozen comments where two matter,
and the maintainer still reads all twelve to work out which two.

This skill is mostly detection procedure rather than review advice: a defined reading
order, several passes over the diff, blast-radius checks on files the diff never
opened, and a reproduction before any claim is made. Candidate findings are then
scored on a weighted 10-point rubric, and anything below 8.0 is dropped before the
maintainer sees it. A medium PR yields two or three comments, each with a patch.

The section already covers *requesting* and *receiving* code review; this covers
performing one, so it complements those entries rather than duplicating them.

## Testing

- [x] I have tested this skill with Claude (Code/Web/API)
- [x] The skill works as described
- [x] Installation instructions are clear

## Additional Context

- Self-rated ⭐⭐⭐ per your rating guidelines — the source repo is new, so I am not
  claiming more than "solid, working, clear purpose."
- `pr-review` is one of eight skills in the suite, each self-contained (`SKILL.md`
  plus its own `references/`), so this one installs on its own.
- Your `### 🔒 Security & Performance` section lists `security-review`,
  `dependency-audit`, and `performance-optimization` as Community-needed. The suite
  has all three. I can send them as separate follow-up PRs, since one-skill-per-PR
  is your rule — just say the word.
- Licensed Apache-2.0.