### PR TITLE
Add pdp-audit under new E-commerce & UX category

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
   - [📊 Data & Analysis](#-data--analysis)
   - [💰 Finance & Tax](#-finance--tax)
   - [✍️ Writing & Research](#️-writing--research)
+  - [🛒 E-commerce & UX](#-e-commerce--ux)
   - [🎯 Meta Skills](#-meta-skills)
 - [Skill Collections](#skill-collections)
 - [FAQ](#faq)
@@ -441,6 +442,16 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Status:** Community-needed
 **Description:** Create clear technical documentation following industry best practices.
 **Use Case:** API docs, user manuals, technical specifications
+
+---
+
+### 🛒 E-commerce & UX
+
+#### pdp-audit
+**Source:** [llizell/pdp-audit](https://github.com/llizell/pdp-audit)
+**Description:** Audits ecommerce product detail pages against 82 UX/conversion guidelines and outputs a prioritized, evidence-based report
+**Use Case:** CRO reviews, product page audits, design QA for ecommerce and Shopify teams
+**Stars:** ⭐⭐⭐⭐
 
 ---
 


### PR DESCRIPTION
Adds [pdp-audit](https://github.com/llizell/pdp-audit), following the format from CONTRIBUTING.md.

Since none of the existing categories cover ecommerce/UX work, this PR proposes a small new **🛒 E-commerce & UX** category (added to the ToC as well) — happy to re-file it under an existing category if you prefer.

**What it does:** audits ecommerce product detail pages against 82 UX/conversion guidelines organized by page zone (gallery, buy box, price, variants, shipping & returns, reviews, mobile, trust & accessibility). Live-URL mode via Playwright with screenshots at desktop/mobile widths and DOM inspection; screenshot-only fallback. Output: a prioritized report capped at 12 findings, each with severity, observed evidence, a dev-ready recommendation, and S/M/L effort — uncertain items go to a "verify manually" list instead of findings. Guidelines compiled from freely accessible public sources (WCAG 2.2, FTC/EU guidance, published UX research); MIT licensed; [sample report from a real audit](https://github.com/llizell/pdp-audit/blob/main/examples/sample-report.md) in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)