### PR TITLE
Add adologyai/content-intelligence-plugin to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Looking for curated skill bundles? Start with these collections:
 | [ChatCrystal](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) | 3 | @ZengLiangYi | Local-first memory recall and writeback for AI coding sessions |
 | [Affitor/affiliate-skills](https://github.com/Affitor/affiliate-skills) | 45 | @Affitor | Affiliate marketing full funnel: research, content, SEO, landing pages, distribution, analytics, automation |
 | [noizai/skills](https://github.com/noizai/skills) | 2+ | @noizai | TTS dubbing and companion voice presets |
+| [adologyai/content-intelligence-plugin](https://github.com/adologyai/content-intelligence-plugin) | 14 | @adologyai | Competitive ad and creative intelligence: brand research, content strategy, data exploration, backed by a hosted MCP server |
 
 ---
 


### PR DESCRIPTION
Adds Adology's content-intelligence-plugin to the Skill Collections table.

Adology is competitive ad and creative intelligence for AI agents, backed by a hosted remote MCP server (https://mcp.adologyai.com/mcp) and listed in Anthropic's official MCP connector directory as an approved connector (registry entry com.adologyai/mcp). The plugin repo ships 14 Claude Agent Skills for brand research, content strategy, and competitive data exploration on top of that server.

Repo: https://github.com/adologyai/content-intelligence-plugin
Website: https://adologyai.com

## Skill Information
- **Skill Name:** content-intelligence-plugin (collection of 14 skills)
- **Category:** Skill Collections
- **Repository:** https://github.com/adologyai/content-intelligence-plugin
- **I am the author:** [x] Yes

## Quality Checklist
- [x] Has working SKILL.md files
- [x] Clear documentation
- [x] Active maintenance (commits in last 6 months)
- [x] Relevant to Claude workflows (Code/Web/API)
- [x] No security issues
- [x] Follows format requirements
- [x] Alphabetically sorted within category (Skill Collections is not alphabetized; added at end per existing convention)