### PR TITLE
Add indian-stocks-fundamental-analysis (Finance & Tax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Prompt-based guidance through the income-tax portal for Indian returns
 **Stars:** ⭐⭐⭐
 
+#### indian-stocks-fundamental-analysis
+**Source:** [AlenSarangSatheesh/Indian-Stocks-Fundamental-Analysis-SKILL](https://github.com/AlenSarangSatheesh/Indian-Stocks-Fundamental-Analysis-SKILL) | **Verified:** ⏳
+**Description:** Sector-relative fundamental analysis of listed companies — India-first (NSE/BSE), works globally; document-first, never-invent-a-number.
+**Use Case:** Judging if a stock is fundamentally strong or cheap, forensic accounting checks, and IPO/DRHP assessment — research, not advice
+**Stars:** ⭐⭐⭐
+
 ---
 
 ### ✍️ Writing & Research


### PR DESCRIPTION
Adds **indian-stocks-fundamental-analysis** under **Finance & Tax**.

- Repo: https://github.com/AlenSarangSatheesh/Indian-Stocks-Fundamental-Analysis-SKILL
- Sector-relative, multi-factor fundamental analysis of listed companies (India-first, works globally). Document-first ("never invent a number"), with Screen/Standard/Deep-dive/Forensic/IPO modes, 25 sector playbooks, and dependency-free Python helpers.
- Proper SKILL.md with YAML frontmatter, MIT-licensed, actively maintained.

Checklist:
- [x] Skill works with Claude
- [x] Links valid
- [x] Description under 150 chars
- [x] SKILL.md with YAML frontmatter
- [x] Source repo has recent commits