### PR TITLE
Add mubu-integration to Document & File Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Source:** [anthropics/skills](https://github.com/anthropics/skills) | **Verified:** ✅
 **Description:** PowerPoint presentation creation with templates, charts, and multimedia integration.
 **Use Case:** Automated slide generation, presentation analysis, template customization
-**Stars:** ⭐⭐⭐⭐
+
+#### mubu-integration
+**Source:** [liuboacean/mubu-integration](https://github.com/liuboacean/mubu-integration) | **Verified:** ✅
+**Description:** Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.
+**Use Case:** Syncing Mubu outlines with Markdown, converting outlines to OPML/FreeMind
+**Stars:** ⭐**Stars:** ⭐⭐⭐⭐
 
 ---
 


### PR DESCRIPTION
Hi! I'd like to add **mubu-integration** to this list.

**What it is:** Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.

- Repo: https://github.com/liuboacean/mubu-integration
- 中文落地页: https://github.com/liuboacean/mubu-integration/blob/main/README.zh-CN.md
- Positioned as an AI Agent Skill (Claude Code / Agents), not just a CLI.

Accurate description (no exaggeration): outline↔Markdown sync with lossless round-trip, OPML/FreeMind export.

Thanks for maintaining this awesome list!
