### PR TITLE
Add auteur to Media & Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,11 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Creative coding, data visualization, generative design
 **Stars:** ⭐⭐⭐
 
+#### auteur
+**Source:** [agiwhitelist/auteur](https://github.com/agiwhitelist/auteur) | **Verified:** ⏳
+**Description:** Build complete websites from a written art-direction commitment, gated by a zero-dependency slop linter and a Playwright FPS/contrast check that fail the build.
+**Use Case:** Landing pages, scroll-driven storytelling sites, multi-screen product UI held to one design system
+
 #### video-editing-helper
 **Status:** Community-needed
 **Description:** Assist with video editing workflows, ffmpeg commands, and transitions.


### PR DESCRIPTION
Adds `auteur` — a skill for building complete websites, where the quality bar is enforced by executable gates rather than by prose.

**Repo:** https://github.com/agiwhitelist/auteur · MIT · `SKILL.md` at repo root with valid frontmatter

**What it does.** Art direction is committed to a written sheet (one brand hue, a type system, a motion budget, named anti-references) before any markup exists, so the build cannot drift. Assets are generated locally, and nothing ships until two gates pass:

- `slopscan` — zero-dependency linter that fails the build on generic-AI-design tells
- `motionqa` — Playwright run under 4x CPU throttle: FPS floor, long tasks, console errors, contrast

**Proof:** ten live showcase sites at https://agiwhitelist.github.io/auteur/ — each one passes both gates, and you can reproduce the linter result yourself in one command against any of them.

Placed in Media & Content Creation next to the other visual-creation skills. Left the Stars line off — that rating is yours to set, not mine.