### PR TITLE
Add sales-framework skill by KudoMetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Naming a company or product across languages; catching a name that reads well at home but fails abroad
 **Stars:** ⭐⭐⭐
 
+#### sales-framework
+**Source:** [KudoMetrics-Techologies-Private-Limited/sales-framework](https://github.com/KudoMetrics-Techologies-Private-Limited/sales-framework) | **Verified:** ⏳
+**Description:** Loads proven sales psychology into landing pages, pitches, and conversion copy. Combines goatherders' 7 principles (20yr sales veteran) with Ramachandran's CXO deal-making framework.
+**Use Case:** Landing page copy, pricing pages, conversion optimization, client proposals, cold outreach sequences
+**Stars:** ⭐⭐⭐⭐
+
 #### internal-comms
 **Source:** Community | **Verified:** ⏳
 **Description:** Draft internal communications, memos, and team announcements.


### PR DESCRIPTION
Adds the sales-framework Claude Code skill to the marketing/business section.

**Repo:** https://github.com/KudoMetrics-Techologies-Private-Limited/sales-framework
**Install:** `npx skills add KudoMetrics-Techologies-Private-Limited/sales-framework --skill sales-framework`
**License:** MIT

Combines goatherders' 7 sales principles (famous HN comment, 20yr veteran) with Ramachandran's CXO deal-making framework (15yr, $1M+ deals). Use for landing pages, pricing, conversion copy, and client proposals.