### PR TITLE
Add project-planning-journaling skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Process mapping, AS-IS analysis with pain points, TO-BE automation roadmaps
 **Stars:** ⭐⭐⭐
 
+#### project-planning-journaling
+**Source:** [mh-mansouri/Project-Planning-Journaling](https://github.com/mh-mansouri/Project-Planning-Journaling) | **Verified:** ⏳
+**Description:** Scopes a project (type, repo, timeline, public vs. private-product path) before any code is written, then sets up and maintains a living, resumable documentation journal with a weekly routine review.
+**Use Case:** Starting a new project, documenting what's been built so far, resuming work in a fresh session without re-reading chat history
+**Stars:** ⭐⭐⭐⭐
+
 #### documentation-generator
 **Status:** Community-needed
 **Description:** Auto-generate API documentation and keep docs synchronized with code.


### PR DESCRIPTION
Fills the Documentation & Automation gap next to the community-needed documentation-generator/changelog-automation placeholders: scopes a project (type, repo status, timeline, public-vs-private-product path, dev style) before any code is written, then sets up and maintains a living, resumable documentation journal with a weekly routine review.

Placed after process-builder, before the community-needed stubs.

# Pull Request: Add Skill

## Skill Information

- **Skill Name:**
- **Category:**
- **Repository URL:**
- **I am the author of this skill:** [ ] Yes [ ] No

## Quality Checklist

Please verify that your submission meets these requirements:

- [ ] Has working `SKILL.md` file with YAML frontmatter
- [ ] Clear, concise documentation
- [ ] Active maintenance (commits within last 6 months)
- [ ] Relevant to Claude workflows (Code, Web, or API)
- [ ] No security vulnerabilities or malicious code
- [ ] Follows format requirements in CONTRIBUTING.md
- [ ] Alphabetically sorted within category
- [ ] All links are valid and working
- [ ] Description is under 150 characters
- [ ] Includes specific use case

## Skill Entry

Please paste your formatted skill entry here:

```markdown
#### skill-name
**Source:** [owner/repo](https://github.com/owner/repo)
**Description:**
**Use Case:**
**Stars:** ⭐⭐⭐⭐⭐
```

## Why This Skill is Valuable

Please explain why this skill would be valuable to the Claude community:



## Testing

- [ ] I have tested this skill with Claude (Code/Web/API)
- [ ] The skill works as described
- [ ] Installation instructions are clear

## Additional Context

Add any other context, screenshots, or examples about the skill here:



---

**By submitting this PR, I confirm that:**
- This contribution is my own work or I have the right to submit it
- I've read and followed the CONTRIBUTING.md guidelines
- I understand this project uses the MIT License
