### PR TITLE
Add harmonic-mixing and identify-song to Media & Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,18 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Quick mockups, diagrams, visual brainstorming
 **Stars:** ⭐⭐⭐
 
+#### harmonic-mixing
+**Source:** [songfinder-dev/songfinder-skills](https://github.com/songfinder-dev/songfinder-skills/tree/main/skills/harmonic-mixing) | **Verified:** ⏳
+**Description:** Get a track's BPM, musical key and Camelot code, then build beatmatched or harmonically compatible playlists.
+**Use Case:** DJ set planning, playlist sequencing, working out why two tracks clash
+**Stars:** ⭐⭐⭐
+
+#### identify-song
+**Source:** [songfinder-dev/songfinder-skills](https://github.com/songfinder-dev/songfinder-skills/tree/main/skills/identify-song) | **Verified:** ⏳
+**Description:** Identify what song is playing in a link or an audio file, then look up its ISRC, album, label and streaming links.
+**Use Case:** Naming an unknown track in a video, tagging a music library, finding a song you can only describe by where you heard it
+**Stars:** ⭐⭐⭐
+
 #### slack-gif-creator
 **Source:** Community | **Verified:** ⏳
 **Description:** Generate custom GIFs for Slack communication and team engagement.


### PR DESCRIPTION
# Pull Request: Add Skill

## Skill Information

- **Skill Name:** `identify-song` and `harmonic-mixing` (two skills, one repository)
- **Category:** Media & Content Creation
- **Repository URL:** https://github.com/songfinder-dev/songfinder-skills
- **I am the author of this skill:** [x] Yes [ ] No

## Quality Checklist

- [x] Has working `SKILL.md` file with YAML frontmatter
- [x] Clear, concise documentation
- [x] Active maintenance (commits within last 6 months)
- [x] Relevant to Claude workflows (Code, Web, or API)
- [x] No security vulnerabilities or malicious code — both skills are plain Markdown, no scripts, no install step
- [x] Follows format requirements in CONTRIBUTING.md
- [x] Alphabetically sorted within category — inserted between `canvas-design` and `slack-gif-creator`
- [x] All links are valid and working — both source links return 200
- [x] Description is under 150 characters — 109 and 114
- [x] Includes specific use case

## Skill Entry

```markdown
#### harmonic-mixing
**Source:** [songfinder-dev/songfinder-skills](https://github.com/songfinder-dev/songfinder-skills/tree/main/skills/harmonic-mixing) | **Verified:** ⏳
**Description:** Get a track's BPM, musical key and Camelot code, then build beatmatched or harmonically compatible playlists.
**Use Case:** DJ set planning, playlist sequencing, working out why two tracks clash
**Stars:** ⭐⭐⭐

#### identify-song
**Source:** [songfinder-dev/songfinder-skills](https://github.com/songfinder-dev/songfinder-skills/tree/main/skills/identify-song) | **Verified:** ⏳
**Description:** Identify what song is playing in a link or an audio file, then look up its ISRC, album, label and streaming links.
**Use Case:** Naming an unknown track in a video, tagging a music library, finding a song you can only describe by where you heard it
**Stars:** ⭐⭐⭐
```

I left `**Stars:**` at ⭐⭐⭐ to match the other community entries — please adjust to whatever rating you think fits.

## Why This Skill is Valuable

"What song is this?" and "what key is it in?" are questions an assistant currently cannot answer at all — there is no offline way to recognise audio or to know a track's tempo and key.

`identify-song` covers recognition from a link (YouTube, TikTok, Instagram, SoundCloud, Bilibili, X) or a local audio file, plus catalogue lookup for ISRC, album, label, release date and streaming links.

`harmonic-mixing` covers the analysis side: BPM, musical key, Camelot code, harmonically compatible keys, energy/danceability/valence, and whole-playlist analysis for set building.

The backing service needs no API key and no account, so the skills work immediately after install with nothing to configure.

## Testing

- [ ] I have tested this skill with Claude (Code/Web/API)
- [x] The skill works as described
- [x] Installation instructions are clear

On the first box, I would rather be precise than tick it: what I verified is every HTTP endpoint the two `SKILL.md` files document, called exactly as documented, against production —

| Endpoint | Result |
|---|---|
| `GET /api/track/search?q=` | 200, returns ISRC |
| `GET /api/track/detail?isrc=` | 200, tempo/key/Camelot present |
| `GET /api/track/similar?isrc=` | 200 |
| `POST /api/track/playlist` `{"playlist": "<deezer url>"}` | 200, analysed 80 of 100 tracks |

I did not exercise `POST /api/music/recognize` for this PR because each call spends real recognition quota; it is covered by the CI smoke test of the sibling MCP server, which drives the same endpoint.

## Additional Context

Layout is `skills/<name>/SKILL.md`, so `npx skills add songfinder-dev/songfinder-skills` installs both. MIT licensed. Same toolkit is also published as an MCP server if that is ever useful for cross-referencing.

---

**By submitting this PR, I confirm that:**
- This contribution is my own work or I have the right to submit it
- I've read and followed the CONTRIBUTING.md guidelines
- I understand this project uses the MIT License
