### PR TITLE
Add pvr-inox-radar to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Monthly D2C business reviews, revenue/retention/margin diagnostics, automated consultant-quality analysis
 **Stars:** ⭐⭐⭐
 
+#### pvr-inox-radar
+**Source:** [karanb192/pvr-inox-radar](https://github.com/karanb192/pvr-inox-radar) | **Verified:** ✅
+**Description:** Maps PVR INOX showtimes across an Indian city from one plain-English ask, with counted seats-together and drive times. India, PVR INOX only.
+**Use Case:** Picking tonight's show: cheapest recliners nearby, 4 seats together for IMAX on Saturday, what's playing in 4DX in Bengaluru
+**Stars:** ⭐⭐⭐
+
 #### data-visualization
 **Status:** Community-needed
 **Description:** Create charts, graphs, and interactive visualizations from datasets.


### PR DESCRIPTION
## Skill Information

- **Skill Name:** pvr-inox-radar
- **Category:** Data & Analysis
- **Repository URL:** https://github.com/karanb192/pvr-inox-radar
- **I am the author of this skill:** [x] Yes [ ] No

## Quality Checklist

- [x] Has working `SKILL.md` file with YAML frontmatter (skills/pvr-inox-radar/SKILL.md)
- [x] Clear, concise documentation
- [x] Active maintenance (last push 1 Sep 2026, v0.1.5)
- [x] Relevant to Claude workflows (Claude Code plugin, plus Codex and Gemini via install.sh)
- [x] No security vulnerabilities or malicious code (read-only, stdlib only, no credentials)
- [x] Follows format requirements in CONTRIBUTING.md
- [x] Alphabetically sorted within category (after claude-ecom, before the community-needed stubs)
- [x] All links are valid and working
- [x] Description is under 150 characters (140)
- [x] Includes specific use case

## Skill Entry

```markdown
#### pvr-inox-radar
**Source:** [karanb192/pvr-inox-radar](https://github.com/karanb192/pvr-inox-radar) | **Verified:** ✅
**Description:** Maps PVR INOX showtimes across an Indian city from one plain-English ask, with counted seats-together and drive times. India, PVR INOX only.
**Use Case:** Picking tonight's show: cheapest recliners nearby, 4 seats together for IMAX on Saturday, what's playing in 4DX in Bengaluru
**Stars:** ⭐⭐⭐
```

## Why This Skill is Valuable

One plain-English ask ("cheapest recliners near Sector 56 tonight, 2 seats together") becomes one self-contained HTML map: every nearby PVR INOX venue as a pin, showtime chips, seats-together counted from the live seat map rather than read off an availability label, drive-time estimates, and a deep link per show into PVR's own seat page. Scope is deliberately narrow (the PVR INOX chain in India), which is why it gets a conservative three-star rating.

## Testing

- [x] I have tested this skill with Claude (Code/Web/API)
- [x] The skill works as described
- [x] Installation instructions are clear

## Additional Context

180 offline tests, python3 stdlib only, rate-limited and read-only by design (it never books). Demo GIF at the top of the repo README is a real run from 1 Sep 2026.

---

**By submitting this PR, I confirm that:**
- This contribution is my own work or I have the right to submit it
- I've read and followed the CONTRIBUTING.md guidelines
- I understand this project uses the MIT License
