### PR TITLE
Add babyGao/agent-pilot-skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Looking for curated skill bundles? Start with these collections:
 | [ChatCrystal](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) | 3 | @ZengLiangYi | Local-first memory recall and writeback for AI coding sessions |
 | [Affitor/affiliate-skills](https://github.com/Affitor/affiliate-skills) | 45 | @Affitor | Affiliate marketing full funnel: research, content, SEO, landing pages, distribution, analytics, automation |
 | [noizai/skills](https://github.com/noizai/skills) | 2+ | @noizai | TTS dubbing and companion voice presets |
+| [babyGao/agent-pilot-skills](https://github.com/babyGao/agent-pilot-skills) | 6 | @babyGao | Outbound sales pipeline, parallel agent coordination, two-model adversarial review, hand-drawn tech illustration |
 
 ---
 


### PR DESCRIPTION
### What it is

[agent-pilot-skills](https://github.com/babyGao/agent-pilot-skills) is a 6-skill collection for AI coding agents, each capturing a workflow that has actually been run rather than a hypothetical one.

| Skill | What it does |
|---|---|
| `hello-boss` | Outbound sales pipeline - enumerate every industry that could buy what you do, resolve prospects' operating companies and emails from public business registries, write one cold email that earns replies |
| `dispatching-codex-gpt` | Hand a task to GPT via Codex as an independent second model - adversarial review, parallel execution, cross-checking |
| `orchestrating-parallel-research` | Coordinate many independent tasks across isolated workspaces - split, isolate, dispatch, observe |
| `publishing-to-cnblogs` | Publish or cross-post an article with images re-hosted, via REST API rather than fragile editor scripting |
| `sketch-tech-illustration` | A hand-drawn warm-toned illustration spec for AI/tech storytelling - locked palette, per-element rules |
| `huopan-listing-search` | One-call commercial-property listing search rendered as Markdown cards |

Each lives in `skills/<name>/` with a `SKILL.md` plus bundled `references/` and, where useful, `scripts/` and `templates/`. MIT licensed, no paid services required.

Adds one row to the Skill Collections table.