### PR TITLE
Add reading-analysis skill (English exam reading comprehension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Description:** Create clear technical documentation following industry best practices.
 **Use Case:** API docs, user manuals, technical specifications
 
+#### reading-analysis
+**Source:** [shenquan520/reading-analysis](https://github.com/shenquan520/reading-analysis) | **Verified:** ⏳
+**Description:** AI reading-analysis skill for English exams (Gaokao / CET-4/6 / Kaoyan): question-type mapping, 10-class distractor taxonomy, and a 125-card methodology library; generates fully-explained annotated passages with per-paragraph summaries.
+**Use Case:** English exam prep, self-study reading analysis without a teacher, training distractor-option judgment
+**Stars:** ⭐
+
 ---
 
 ### 🎯 Meta Skills


### PR DESCRIPTION
Adds [reading-analysis](https://github.com/shenquan520/reading-analysis) to the Writing & Research section.

- **What it does:** an AI reading-analysis skill for English exams (Gaokao / CET-4/6 / Kaoyan) that maps question types, applies a 10-class distractor taxonomy, and draws on a 125-card methodology library to generate fully-explained annotated passages (per-paragraph summaries, sticky-note reasoning traces, skill gaps).
- **Why it's valuable:** built from months of real exam-question practice; the methodology library is distilled from actual tested questions rather than generated one-shot. Open source under CC BY-NC-SA 4.0.
- **Install:** clone the repo into a Claude Code / WorkBuddy skills directory and start using it.