### PR TITLE
Add kurashi-skill collection and furusato-nozei skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,12 @@ Confused about when to use Skills vs other Claude customization methods? Here's 
 **Use Case:** Prompt-based guidance through the income-tax portal for Indian returns
 **Stars:** ⭐⭐⭐
 
+#### furusato-nozei
+**Source:** [tahodev/kurashi-skill](https://github.com/tahodev/kurashi-skill/tree/main/furusato-nozei)
+**Description:** Calculates Japan's furusato nozei (hometown tax) donation limit from salary or taxable income - pure calculation, no API.
+**Use Case:** When users ask about furusato nozei donation caps, deduction estimates, or the one-stop exception
+**Stars:** ⭐⭐⭐⭐
+
 ---
 
 ### ✍️ Writing & Research
@@ -542,6 +548,7 @@ Looking for curated skill bundles? Start with these collections:
 | [ChatCrystal](https://github.com/ZengLiangYi/ChatCrystal/tree/main/skills) | 3 | @ZengLiangYi | Local-first memory recall and writeback for AI coding sessions |
 | [Affitor/affiliate-skills](https://github.com/Affitor/affiliate-skills) | 45 | @Affitor | Affiliate marketing full funnel: research, content, SEO, landing pages, distribution, analytics, automation |
 | [noizai/skills](https://github.com/noizai/skills) | 2+ | @noizai | TTS dubbing and companion voice presets |
+| [tahodev/kurashi-skill](https://github.com/tahodev/kurashi-skill) | 5 | @tahodev | Japanese daily life on official open data: JMA weather, disaster alerts, national holidays, furusato tax, library search |
 
 ---
 


### PR DESCRIPTION
# Pull Request: Add Skill

## Skill Information

- **Skill Name:** furusato-nozei (from the kurashi-skill collection)
- **Category:** 💰 Finance & Tax
- **Repository URL:** https://github.com/tahodev/kurashi-skill
- **I am the author of this skill:** [x] Yes [ ] No

## Quality Checklist

Please verify that your submission meets these requirements:

- [x] Has working `SKILL.md` file with YAML frontmatter
- [x] Clear, concise documentation
- [x] Active maintenance (commits within last 6 months)
- [x] Relevant to Claude workflows (Code, Web, or API)
- [x] No security vulnerabilities or malicious code
- [x] Follows format requirements in CONTRIBUTING.md
- [ ] Alphabetically sorted within category
- [x] All links are valid and working
- [x] Description is under 150 characters
- [x] Includes specific use case

## Skill Entry

```markdown
#### furusato-nozei
**Source:** [tahodev/kurashi-skill](https://github.com/tahodev/kurashi-skill/tree/main/furusato-nozei)
**Description:** Calculates Japan's furusato nozei (hometown tax) donation limit from salary or taxable income - pure calculation, no API.
**Use Case:** When users ask about furusato nozei donation caps, deduction estimates, or the one-stop exception
**Stars:** ⭐⭐⭐⭐
```

This PR also adds the parent collection [tahodev/kurashi-skill](https://github.com/tahodev/kurashi-skill) to the Skill Collections table (5 skills: JMA weather, disaster alerts, national holidays, furusato tax, library search).

## Why This Skill is Valuable

Furusato nozei deduction-limit questions are common for anyone working in Japan, and the official calculation is fiddly (income brackets, resident tax rules). This skill computes the limit locally with no API and no login, using the 令和7 (2025) tax tables with source dates documented in the repo. The kurashi-skill collection applies the same pattern - official Japanese government open data, no login, no scraping - across weather, disaster alerts, holidays, and library search.

## Testing

- [ ] I have tested this skill with Claude (Code/Web/API)
- [x] The skill works as described
- [x] Installation instructions are clear

## Additional Context

The skill is installed with `npx skills add tahodev/kurashi-skill` and its calculation tables were corrected against official 令和7 sources (with source dates in the repo). A scheduled CI workflow curl-checks every external endpoint the skills rely on, so silent upstream changes get caught. The skill content is written in Japanese since it serves Japan-based workflows; the README has English summaries.

Note on sorting: the existing Finance & Tax entries are not alphabetical (itr-wala precedes file-itr), so the new entry was appended after file-itr.

---

**By submitting this PR, I confirm that:**
- This contribution is my own work or I have the right to submit it
- I've read and followed the CONTRIBUTING.md guidelines
- I understand this project uses the MIT License